### PR TITLE
More changes towards getting ImageView running

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -37,7 +37,7 @@ export GtkTable, GtkAlignment
 
 # Gtk-specific event handling
 export gtk_doevent, GdkEventMask, GdkModifierType,
-    signal_connect, signal_disconnect,
+    connect, signal_connect, signal_disconnect,
     on_signal_destroy, on_signal_button_press,
     on_signal_button_release, on_signal_motion,
     add_events
@@ -145,7 +145,8 @@ module ShortNames
         get_pointer,
         reveal, configure, draw, cairo_context,
         visible, destroy,
-        hasparent, toplevel
+        hasparent, toplevel,
+        connect
 
     # Gtk objects
     const G_ = GAccessor

--- a/src/gdk.jl
+++ b/src/gdk.jl
@@ -204,7 +204,9 @@ baremodule GdkKeySyms
   const GDK_KEY_Hyper_R = 0xffee
 end
 
-immutable GdkEventButton
+abstract GdkEventI
+
+immutable GdkEventButton <: GdkEventI
     event_type::Enum
     gdk_window::Ptr{Void}
     send_event::Int8
@@ -219,7 +221,7 @@ immutable GdkEventButton
     y_root::Float64
 end
 
-immutable GdkEventScroll
+immutable GdkEventScroll <: GdkEventI
     event_type::Enum
     gdk_window::Ptr{Void}
     send_event::Int8
@@ -235,7 +237,7 @@ immutable GdkEventScroll
     delta_y::Float64
 end
 
-immutable GdkEventKey
+immutable GdkEventKey <: GdkEventI
     event_type::Enum
     gdk_window::Ptr{Void}
     send_event::Int8
@@ -249,9 +251,9 @@ immutable GdkEventKey
     flags::Uint32
 end
 
-is_modifier(evt::GdkEventKey) = (evt.flags & 0x0001) > 0
+is_modifier(evt::GdkEventKey) = (evt.flags & uint32(1)) > 0
 
-immutable GdkEventMotion
+immutable GdkEventMotion <: GdkEventI
   event_type::Enum
   gdk_window::Ptr{Void}
   send_event::Int8
@@ -266,7 +268,7 @@ immutable GdkEventMotion
   y_root::Float64
 end
 
-immutable GdkEventCrossing
+immutable GdkEventCrossing <: GdkEventI
   event_type::Enum
   gdk_window::Ptr{Void}
   send_event::Int8
@@ -280,4 +282,19 @@ immutable GdkEventCrossing
   detail::Enum
   focus::Cint
   state::Uint32
+end
+
+# Expand this dictionary as more event types get added
+const eventTdict = [
+    "button-press-event" => GdkEventButton,
+    "button-release-event" => GdkEventButton,
+    "enter-notify-event" => GdkEventCrossing,
+    "key-press-event" => GdkEventKey,
+    "key-release-event" => GdkEventKey,
+    "leave-notify-event" => GdkEventCrossing,
+    "motion-notify-event" => GdkEventMotion,
+    "scroll-event" => GdkEventScroll]
+kv = collect(eventTdict)
+for (k,v) in kv
+    eventTdict[replace(k, "-", "_")] = v
 end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -107,19 +107,25 @@ f = BoxLayout(:v); push!(w,f)
 l = Label("label"); push!(f,l)
 b = Button("button"); push!(f,b)
 
+# Callbacks
+ctr = 0
+function cb(obj)
+    global ctr
+    ctr = ctr + 1
+end
+
+id = connect(b, "clicked", cb)
+Gtk.signal_emit(b, "clicked", Void)
+@assert ctr == 1
+Gtk.signal_handler_disconnect(b, id)
+connect(b, "clicked", obj->nothing)
+Gtk.signal_emit(b, "clicked", Void)
+@assert ctr == 1
+
 l[:label] = "new label"
 @assert l[:label,String] == "new label"
 b[:label] = "new label"
 @assert b[:label,String] == "new label"
-#local ctr = 0
-#function cb(path)
-#    global ctr
-#    ctr = ctr + 1
-#end
-#end
-#tk_bind(b, "command", cb)
-#tcl(b, "invoke")
-#@assert ctr == 2
 #img = Image(Pkg.dir("Tk", "examples", "weather-overcast.gif"))
 #map(u-> tk_configure(u, {:image=>img, :compound=>"left"}), (l,b))
 destroy(w)
@@ -131,10 +137,11 @@ check[:active] = true
 @assert check[:active,Bool] == true
 check[:label] = "new label"
 @assert check[:label,String] == "new label"
-#ctr = 0
-#tk_bind(check, "command", cb)
-#tcl(check, "invoke")
-#@assert ctr == 1
+
+ctr = 0
+connect(check, "clicked", cb)
+Gtk.signal_emit(check, "clicked", Void)
+@assert ctr == 1
 destroy(w)
 
 ## radio


### PR DESCRIPTION
The most important of these---and the one that deserves the most careful scrutiny---is the patch adding `connect`. I added it because I was finding it awkward to pass extra data to callbacks. Usage of `connect` would take either of the following patterns:

```
connect(upbutton, "clicked", obj -> upbutton_cb(obj, state, displayfunc))
connect(upbutton, "button-press-event", (obj, event) -> upbutton_cb(obj, event, state, displayfunc))
```

The latter is used when there is a `GdkEvent` associated with the signal.

Overall, I think this is a fairly nice interface, but there are alternatives. Rather than using an anonymous function to store the extra arguments, we could presumably define it as

```
connect(object, signal, func, args...)
```

where `func` gets called as `func(obj, event, args...)`, and set the `args` tuple as the data argument of `g_signal_connect_data`. However, one problem with that interface is how to handle `gconnectflags`. So the anonymous-function interface seemed the better way to go.

I should also mention that do find the current `signal_connect` slightly confusing:
- The `data` argument is named `closure`.
- The `data` argument is last, after `gconnectflags`, which is presumably a rarely-used option. That propagates to `on_signal_button_press` and friends, meaning that most usages of this function might look like this:

```
on_signal_button_press(func, widget, 0, extradata)
```

where `extradata` contains whatever state information the widget callback needs in order to do its job. If one could pass it as

```
on_signal_button_press(func, widget, 0, extradata1, extradata2, ...)
```

then that argument order might make more sense, but that doesn't work either unless `signal_connect`'s function declaration were written in terms of `closure...`.

I suspect I'm simply not understanding how you intended to use it, and perhaps that's part of why I decided to create a wrapper.

The other patches in this PR (so far) should be fairly straightforward, as long as you like the names. The key constants are a bit awkward to use in practice,

```
if event.keyval == Gtk.GdkKeySyms.GDK_KEY_Up
    # do something
end
```

which is quite a lot of characters to type in front of the key constant. Though naturally, one can say

```
const KSYM = Gtk.GdkKeySyms
```

and shorten it. (Seemingly, one can't say `using` for a `baremodule`.)
