### PR TITLE
Allow setting a custom icon in a button

### DIFF
--- a/src/buttons.jl
+++ b/src/buttons.jl
@@ -18,6 +18,15 @@ GtkButton() = GtkButton(ccall((:gtk_button_new,libgtk),Ptr{GObject},()))
 GtkButton(title::String) =
     GtkButton(ccall((:gtk_button_new_with_mnemonic,libgtk),Ptr{GObject},
         (Ptr{Uint8},), bytestring(title)))
+function GtkButton(icon::GdkPixbuf)
+    btn = GtkButton()
+    img = GtkImage(icon)
+    ccall((:gtk_button_set_image,libgtk), Void, (Ptr{GObject}, Ptr{GObject}), btn, img)
+#     btn[:relief] = 2 # GTK_RELIEF_NONE
+    btn[:width_request] = img[:width_request] = size(icon, 1)
+    btn[:height_request] = img[:height_request] = size(icon, 2)
+    btn
+end
 
 @GType GtkCheckButton <: GtkBin
 GtkCheckButton() = GtkCheckButton(ccall((:gtk_check_button_new,libgtk),Ptr{GObject},()))

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -195,7 +195,8 @@ function GdkPixbuf(;stream=nothing,resource_path=nothing,filename=nothing,xpm_da
             return pixbuf !== C_NULL
         end
     elseif data !== nothing
-        @assert(width==-1 && height==-1,"GdkPixbuf cannot set the width/height of a image from data")
+        width = size(data,1)
+        height = size(data,2)
         pixbuf = ccall((:gdk_pixbuf_new_from_data,libgdk_pixbuf),Ptr{GObject},
             (Ptr{Uint8},Cint,Cint,Cint,Cint,Cint,Cint,Ptr{Void},Any),
             data,0,convert(Bool,has_alpha),8,width,height,size(data,1)*sizeof(eltype(data)),
@@ -302,6 +303,14 @@ function GtkImage(;resource_path=nothing,filename=nothing,icon_name=nothing,size
     return img
 end
 empty!(img::GtkImage) = ccall((:gtk_image_clear,libgtk),Void,(Ptr{GObject},),img)
+
+function GdkPixbuf(img::GtkImage)
+    p = ccall((:gtk_image_get_pixbuf,libgtk),Ptr{GObject},(Ptr{GObject},),img)
+    if p == C_NULL
+        error("empty image")
+    end
+    GdkPixbuf(p)
+end
 
 
 @GType GtkProgressBar <: GtkWidget


### PR DESCRIPTION
I had forgotten I had another independent change queued up; here it is if you want it.

I didn't find a way to get rid of the `inner-border` from C, although there seems to be a way to do it if you're specifying the interface using XML files. Consequently, all buttons are drawn with a padded border around the supplied icon. (You can eliminate the visible outer boundary using the commented-out setting of `:relief`, but hovering over the button shows you that this doesn't really do what I intended.) So it seemed best to just live with the border; it's not a big deal, and indeed Tk produces a similar result.
