### PR TITLE
1-based indexing in delete! for combobox

### DIFF
--- a/src/lists.jl
+++ b/src/lists.jl
@@ -52,5 +52,5 @@ if gtk_version == 3
 end
 
 delete!(cb::GtkComboBoxText,i::Integer) =
-    (ccall((:gtk_combo_box_text_remove,libgtk),Void,(Ptr{GObject},Cint),cb,i); cb)
+    (ccall((:gtk_combo_box_text_remove,libgtk),Void,(Ptr{GObject},Cint),cb,i-1); cb)
 


### PR DESCRIPTION
This makes the delete! method use 1-based indexing for combobox.
