### PR TITLE
Small bugfix in get_iface_decl + macro useful in GI.jl

### DIFF
--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -106,7 +106,7 @@ function get_iface_decl(name::Symbol, iname::Symbol, gtyp::GType)
     piname = symbol(string(pname,'I'))
     piface_decl = get_iface_decl(pname, piname, parent)
     quote
-        if $(Meta.quot(iname)) in keys(gtype_ifaces)
+        if $(Meta.quot(name)) in keys(gtype_ifaces)
             const $(esc(iname)) = gtype_ifaces[$(Meta.quot(name))]
         else
             $piface_decl
@@ -138,6 +138,12 @@ function get_type_decl(name,iname,gtyp,gtype_decl)
         end
         $(gtype_decl)
     end
+end
+
+macro type_decl(name,gtyp,getgtype)
+    iname = symbol(string(name,'I'))
+    gtype_decl = :( g_type(::Type{$(esc(name))}) = $(esc(getgtype)) )
+    get_type_decl(name,iname,gtyp,gtype_decl)
 end
 
 macro Gtype(name,lib,symname)


### PR DESCRIPTION
Small name/iname fix, and a macro that will enable GI.jl to (eventually) generate cachable code.
