### PR TITLE
tests.jl: Stock is not defined for Gtk3

### DIFF
--- a/test/tests.jl
+++ b/test/tests.jl
@@ -426,10 +426,12 @@ destroy(win)
 #destroy(w)
 
 ## Selectors
-dlg = FileChooserDialog("Select file", NullContainer(), FileChooserAction.OPEN,
-                        Stock.CANCEL, GtkResponseType.CANCEL,
-                        Stock.OPEN, GtkResponseType.ACCEPT)
-destroy(dlg)
+if Gtk.gtk_version == 2
+    dlg = FileChooserDialog("Select file", NullContainer(), FileChooserAction.OPEN,
+                            Stock.CANCEL, GtkResponseType.CANCEL,
+                            Stock.OPEN, GtkResponseType.ACCEPT)
+    destroy(dlg)
+end
 
 ## List view
 ls=ListStore(Int32,Bool)


### PR DESCRIPTION
It's unclear that this is the right fix, actually.  `GTK_STOCK_CANCEL` and `GTK_STOCK_OPEN` are defined for Gtk2, but it's not clear to me if they're also available as `Stock.CANCEL` and `Stock.OPEN`. 

Edit: `*OK` -> `*OPEN`
