### PR TITLE
add BinDeps and WinRPM to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 Cairo 0.2.2
 julia 0.2-
+BinDeps
+@windows WinRPM


### PR DESCRIPTION
ref #105 - if someone tried to install Gtk before any other packages that depend on BinDeps or WinRPM, they will get errors.
