### PR TITLE
Make it easy to construct a dummy `GdkEventKey`, plus fix new deprecations

### DIFF
--- a/deps/ext.jl
+++ b/deps/ext.jl
@@ -6,8 +6,14 @@ if isfile(_depspath)
     include(_depspath)
 end
 
+if VERSION >= v"0.5.0-dev+4257"
+    const KERNEL = Base.Sys.KERNEL
+else
+    const KERNEL = Base.OS_NAME
+end
+
 if gtk_version == 3
-    if OS_NAME == :Windows
+    if KERNEL == :Windows
         @assign_if_unassigned libgtk = "libgtk-3-0"
         @assign_if_unassigned libgdk = "libgdk-3-0"
     else
@@ -15,10 +21,10 @@ if gtk_version == 3
         @assign_if_unassigned libgdk = "libgdk-3"
     end
 elseif gtk_version == 2
-    if OS_NAME == :Darwin
+    if KERNEL == :Darwin
         @assign_if_unassigned libgtk = "libgtk-quartz-2.0"
         @assign_if_unassigned libgdk = "libgdk-quartz-2.0"
-    elseif OS_NAME == :Windows
+    elseif KERNEL == :Windows
         @assign_if_unassigned libgtk = "libgtk-win32-2.0-0"
         @assign_if_unassigned libgdk = "libgdk-win32-2.0-0"
     else
@@ -29,7 +35,7 @@ else
     error("Unsupported Gtk version $gtk_version")
 end
 
-if OS_NAME == :Windows
+if KERNEL == :Windows
     @assign_if_unassigned libgdk_pixbuf = "libgdk_pixbuf-2.0-0"
     @assign_if_unassigned libgio = "libgio-2.0-0"
 else

--- a/deps/ext_glib.jl
+++ b/deps/ext_glib.jl
@@ -4,7 +4,13 @@ if isfile(_depspath)
     include(_depspath)
 end
 
-if OS_NAME == :Windows
+if VERSION >= v"0.5.0-dev+4257"
+    const KERNEL = Base.Sys.KERNEL
+else
+    const KERNEL = Base.OS_NAME
+end
+
+if KERNEL == :Windows
     @assign_if_unassigned libgobject = "libgobject-2.0-0"
     @assign_if_unassigned libglib = "libglib-2.0-0"
 else

--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -44,8 +44,14 @@ module CompatGLib
     TupleType(types...) = Tuple{types...}
     const unsafe_convert = Base.unsafe_convert
     import Base.Libdl: dlopen, dlsym_e
+    if VERSION >= v"0.5.0-dev+4257"
+        using Base.Sys.WORD_SIZE
+    else
+        using Base.WORD_SIZE
+    end
 end
 importall .CompatGLib
+using .CompatGLib.WORD_SIZE
 
 # local function, handles Symbol and makes UTF8-strings easier
 typealias AbstractStringLike Union{AbstractString,Symbol}

--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -49,9 +49,14 @@ importall .CompatGLib
 
 # local function, handles Symbol and makes UTF8-strings easier
 typealias AbstractStringLike Union{AbstractString,Symbol}
-bytestring(s) = Base.bytestring(s)
+bytestring(s) = String(s)
 bytestring(s::Symbol) = s
 bytestring(s::Ptr{UInt8},own::Bool) = String(pointer_to_array(s,Int(ccall(:strlen,Csize_t,(Ptr{UInt8},),s)),own))
+if VERSION >= v"0.5.0-dev+4200"
+    bytestring(s::Ptr{UInt8}) = String(s)
+else
+    bytestring(s::Ptr{UInt8}) = Base.bytestring(s)
+end
 
 include(joinpath("..","..","deps","ext_glib.jl"))
 

--- a/src/GLib/gvalues.jl
+++ b/src/GLib/gvalues.jl
@@ -155,7 +155,7 @@ end
 function getproperty{T}(w::GObject, name::AbstractStringLike, ::Type{T})
     v = gvalue(T)
     ccall((:g_object_get_property,libgobject), Void,
-        (Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, bytestring(name), v)
+        (Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, GLib.bytestring(name), v)
     val = v[T]
     ccall((:g_value_unset,libgobject),Void,(Ptr{GValue},), v)
     return val
@@ -164,7 +164,7 @@ end
 setproperty!{T}(w::GObject, name::AbstractStringLike, ::Type{T}, value) = setproperty!(w, name, convert(T,value))
 function setproperty!(w::GObject, name::AbstractStringLike, value)
     ccall((:g_object_set_property, libgobject), Void,
-        (Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, bytestring(name), gvalue(value))
+        (Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, GLib.bytestring(name), gvalue(value))
     w
 end
 
@@ -193,7 +193,7 @@ function show(io::IO, w::GObject)
         else
             first = false
         end
-        print(io,bytestring(param.name))
+        print(io,GLib.bytestring(param.name))
         if (param.flags & READABLE) != 0 &&
            (param.flags & DEPRECATED) == 0 &&
            (ccall((:g_value_type_transformable,libgobject),Cint,
@@ -201,7 +201,7 @@ function show(io::IO, w::GObject)
             ccall((:g_object_get_property,libgobject), Void,
                 (Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, param.name, v)
             str = ccall((:g_value_get_string,libgobject),Ptr{UInt8},(Ptr{GValue},), v)
-            value = (str == C_NULL ? "NULL" : bytestring(str))
+            value = (str == C_NULL ? "NULL" : GLib.bytestring(str))
             if param.value_type == g_type(AbstractString) && str != C_NULL
                 print(io,"=\"",value,'"')
             else

--- a/src/GLib/signals.jl
+++ b/src/GLib/signals.jl
@@ -39,7 +39,7 @@ function signal_connect(cb::Function, w::GObject, sig::AbstractStringLike, after
 end
 function _signal_connect(cb::Function, w::GObject, sig::AbstractStringLike, after::Bool, gtk_call_conv::Bool, param_types, user_data)
     @assert sizeof_gclosure > 0
-    closuref = ccall((:g_closure_new_object,libgobject), Ptr{Void}, (Cuint, Ptr{GObject}), sizeof_gclosure::Int+WORD_SIZE*2, w)
+    closuref = ccall((:g_closure_new_object,libgobject), Ptr{Void}, (Cuint, Ptr{GObject}), sizeof_gclosure::Int+GLib.WORD_SIZE*2, w)
     closure_env = convert(Ptr{Ptr{Void}}, closuref + sizeof_gclosure)
     if gtk_call_conv
         env = Any[param_types, user_data]
@@ -277,10 +277,10 @@ type _GSourceFuncs
     closure_marshal::Ptr{Void}
 end
 function new_gsource(source_funcs::_GSourceFuncs)
-    sizeof_gsource = WORD_SIZE
+    sizeof_gsource = GLib.WORD_SIZE
     gsource = C_NULL
     while gsource == C_NULL
-        sizeof_gsource += WORD_SIZE
+        sizeof_gsource += GLib.WORD_SIZE
         gsource = ccall((:g_source_new,GLib.libglib),Ptr{Void},(Ptr{_GSourceFuncs},Int),&source_funcs,sizeof_gsource)
     end
     gsource
@@ -352,10 +352,10 @@ sizeof_gclosure = 0
 function __init__gtype__()
     ccall((:g_type_init,libgobject),Void,())
     global jlref_quark = quark"julia_ref"
-    global sizeof_gclosure = WORD_SIZE
+    global sizeof_gclosure = GLib.WORD_SIZE
     closure = C_NULL
     while closure == C_NULL
-        sizeof_gclosure += WORD_SIZE
+        sizeof_gclosure += GLib.WORD_SIZE
         closure = ccall((:g_closure_new_simple,libgobject),Ptr{Void},(Int,Ptr{Void}),sizeof_gclosure,C_NULL)
     end
     ccall((:g_closure_sink,libgobject),Void,(Ptr{Void},),closure)

--- a/src/gdk.jl
+++ b/src/gdk.jl
@@ -142,6 +142,7 @@ immutable GdkEventKey <: GdkEvent
     group::UInt8
     flags::UInt32
 end
+GdkEventKey() = (uz32 = UInt32(0); GdkEventKey(GEnum(0), C_NULL, Int8(0), uz32, uz32, uz32, Int32(0), C_NULL, UInt16(0), 0x00, uz32))
 
 is_modifier(evt::GdkEventKey) = (evt.flags & 0x0001) > 0
 
@@ -178,4 +179,3 @@ end
 
 keyval(name::AbstractString) =
   ccall((:gdk_keyval_from_name,libgdk),Cuint,(Ptr{UInt8},),bytestring(name))
-

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -41,4 +41,6 @@ showall(win)
 end
 destroy(win)
 
+@assert isa(Gtk.GdkEventKey(), Gtk.GdkEventKey)
+
 end


### PR DESCRIPTION
I didn't fix the `@static` deprecation. There's a fix here:

https://github.com/JuliaLang/Compat.jl/commit/f59536084236dfa0437601111a20aab4c82cfba8

I'm increasingly wondering about the wisdom of avoiding Compat.jl.