### PR TITLE
Generate libgtk_version during initialization

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -40,6 +40,11 @@ include("long_exports.jl")
 include("long_leaf_exports.jl")
 include(joinpath("..","deps","ext.jl"))
 
+const libgtk_version = VersionNumber(
+    ccall((:gtk_get_major_version,libgtk),Cint, ()),
+    ccall((:gtk_get_minor_version,libgtk),Cint, ()),
+    ccall((:gtk_get_micro_version,libgtk),Cint, ()))
+
 include("interfaces.jl")
 include("boxes.jl")
 include("gtktypes.jl")


### PR DESCRIPTION
Implement the suggestion https://github.com/JuliaGraphics/Gtk.jl/pull/209#issuecomment-221935860

Will be necessary to conditionally implement things that have been introduced to Gtk during the version 3 cycle.