### PR TITLE
fixed libgtk_version for gtk2

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -40,10 +40,17 @@ include("long_exports.jl")
 include("long_leaf_exports.jl")
 include(joinpath("..","deps","ext.jl"))
 
-const libgtk_version = VersionNumber(
-    ccall((:gtk_get_major_version,libgtk),Cint, ()),
-    ccall((:gtk_get_minor_version,libgtk),Cint, ()),
-    ccall((:gtk_get_micro_version,libgtk),Cint, ()))
+try
+  global const libgtk_version = VersionNumber(
+      ccall((:gtk_get_major_version,libgtk),Cint, ()),
+      ccall((:gtk_get_minor_version,libgtk),Cint, ()),
+      ccall((:gtk_get_micro_version,libgtk),Cint, ()))
+catch
+  global const libgtk_version = VersionNumber(
+      unsafe_load(cglobal((:gtk_major_version,libgtk),Cuint)),
+      unsafe_load(cglobal((:gtk_minor_version,libgtk),Cuint)),
+      unsafe_load(cglobal((:gtk_micro_version,libgtk),Cuint)))
+end
 
 include("interfaces.jl")
 include("boxes.jl")

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -40,12 +40,12 @@ include("long_exports.jl")
 include("long_leaf_exports.jl")
 include(joinpath("..","deps","ext.jl"))
 
-try
+if gtk_version == 3
   global const libgtk_version = VersionNumber(
       ccall((:gtk_get_major_version,libgtk),Cint, ()),
       ccall((:gtk_get_minor_version,libgtk),Cint, ()),
       ccall((:gtk_get_micro_version,libgtk),Cint, ()))
-catch
+else
   global const libgtk_version = VersionNumber(
       unsafe_load(cglobal((:gtk_major_version,libgtk),Cuint)),
       unsafe_load(cglobal((:gtk_minor_version,libgtk),Cuint)),


### PR DESCRIPTION
this is at least a partial fix for gtk2.  specifically it fixes the determination of `libgtk_version`.  i can now `using Gtk` on a linux box with gtk v2.24.23 without any problems.

on a second box though, with v2.18.9, i also have to modify `deps/build.jl` to include `libgtk-x11-2.0` as a dependency.  not sure why this isn't necessary on the first box.  this version of gtk is perhaps not worth supporting as `GtkSpinner` is in `Gtk.jl` and only present in `gtk` since v2.20.