### PR TITLE
Fix syntax error in typealias LListPair

### DIFF
--- a/src/GLib/glist.jl
+++ b/src/GLib/glist.jl
@@ -58,7 +58,7 @@ end
 if VERSION >= v"0.4-"
     typealias LListPair{L} Tuple{LList, Ptr{L}}
 else
-    typealias LListPair{L}(LList, Ptr{L})
+    typealias LListPair{L} (LList, Ptr{L})
 end
 function next{L<:_LList}(::LList, s::LListPair{L})
     (deref(s[2]), (s[1], unsafe_load(s[2]).next))


### PR DESCRIPTION
with v0.6:
 using Gtk
INFO: Precompiling module Gtk.
ERROR: LoadError: LoadError: LoadError: syntax: unexpected end

