### PR TITLE
Allow mouse handler signals to be disconnected

### DIFF
--- a/src/cairo.jl
+++ b/src/cairo.jl
@@ -12,7 +12,8 @@ type GtkCanvas <: GtkDrawingArea # NOT an @GType
     function GtkCanvas(w = -1, h = -1)
         da = ccall((:gtk_drawing_area_new, libgtk), Ptr{GObject}, ())
         ccall((:gtk_widget_set_size_request, libgtk), Void, (Ptr{GObject}, Int32, Int32), da, w, h)
-        widget = new(da, false, false, MouseHandler(), nothing, nothing)
+        ids = Vector{Culong}(0)
+        widget = new(da, false, false, MouseHandler(ids), nothing, nothing)
         widget.mouse.widget = widget
         signal_connect(notify_realize, widget, "realize", Void, ())
         signal_connect(notify_unrealize, widget, "unrealize", Void, ())
@@ -22,10 +23,10 @@ type GtkCanvas <: GtkDrawingArea # NOT an @GType
         else
             signal_connect(canvas_on_expose_event, widget, "expose-event", Cint, (Ptr{Void},))
         end
-        on_signal_button_press(mousedown_cb, widget, false, widget.mouse)
-        on_signal_button_release(mouseup_cb, widget, false, widget.mouse)
-        on_signal_motion(mousemove_cb, widget, 0, 0, false, widget.mouse)
-        on_signal_scroll(mousescroll_cb, widget, false, widget.mouse)
+        push!(ids, on_signal_button_press(mousedown_cb, widget, false, widget.mouse))
+        push!(ids, on_signal_button_release(mouseup_cb, widget, false, widget.mouse))
+        push!(ids, on_signal_motion(mousemove_cb, widget, 0, 0, false, widget.mouse))
+        push!(ids, on_signal_scroll(mousescroll_cb, widget, false, widget.mouse))
         return gobject_ref(widget)
     end
 end

--- a/src/events.jl
+++ b/src/events.jl
@@ -132,14 +132,17 @@ type MouseHandler
     button3motion::Function
     scroll::Function
     stack::MHStack
+    ids::Vector{Culong}
     widget::GtkWidget
 
-    MouseHandler() = new(default_mouse_cb, default_mouse_cb, default_mouse_cb,
-                         default_mouse_cb, default_mouse_cb, default_mouse_cb,
-                         default_mouse_cb, default_mouse_cb, default_mouse_cb,
-                         default_mouse_cb, default_mouse_cb,
-                         Vector{Tuple{Symbol, Function}}())
+    MouseHandler(ids::Vector{Culong}) =
+        new(default_mouse_cb, default_mouse_cb, default_mouse_cb,
+            default_mouse_cb, default_mouse_cb, default_mouse_cb,
+            default_mouse_cb, default_mouse_cb, default_mouse_cb,
+            default_mouse_cb, default_mouse_cb,
+            Vector{Tuple{Symbol, Function}}(), ids)
 end
+MouseHandler() = MouseHandler(Culong[])
 
 const MHPair = Tuple{MouseHandler, Symbol}
 

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -190,10 +190,6 @@ destroy(w)
 end
 
 @testset "ButtonBox" begin
-bb = ButtonBox(:h)
-w = Window(bb, "ButtonBox")
-cancel = Button("Cancel")
-ok = Button("OK")
 ## ButtonBox
 bb = ButtonBox(:h)
 w = Window(bb, "ButtonBox")

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -39,6 +39,7 @@ showall(win)
 @guarded draw(c) do widget
     error("oops")
 end
+@test !isempty(c.mouse.ids)  # check storage of signal-handler ids (see GtkReactive)
 destroy(win)
 
 @test isa(Gtk.GdkEventKey(), Gtk.GdkEventKey)


### PR DESCRIPTION
This stores the `id`s of the default mouse handlers so that they can be manipulated later. In particular, I want this for GtkReactive.jl, since I have my own Reactive-based handlers there.
