### PR TITLE
Small README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If this produces errors, please see [installation troubleshooting](doc/installat
 
 ## Precompilation
 
-Startup time for packages that use Gtk can be dramatically reduced by [precompiling Gtk](doc/precompilation.md).
+Gtk is precompilable by normal mechanisms. For further reduction of startup time for applications that use Gtk, one can even [build it into your local installation of julia](doc/precompilation.md).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ GUI building, using the Gtk library: [http://www.gtk.org/](http://www.gtk.org/)
 Complete Gtk documentation is available at [https://developer.gnome.org/gtk/stable](https://developer.gnome.org/gtk/stable)
 
 The following Documentation on this page is in parts outdated. We currently work on updated documentation that can be found
-[here](http://juliagraphics.github.io/Gtk.jl/latest/)
+[here](http://juliagraphics.github.io/Gtk.jl/latest/).
+
+Finally, there are higher-level wrappers that might simplify your
+usage of Gtk, such as
+[GtkReactive](https://juliagizmos.github.io/GtkReactive.jl/stable/).
 
 ## Installation
 


### PR DESCRIPTION
Updates:
- The original note about precompilation was written before julia 0.4 supported "regular" precompilation. Seems like time to update it.
- I added a link to GtkReactive. I chose the documentation rather than the GitHub site; does that seem reasonable?

(Until v0.0.2 gets merged in METADATA, I recommend the "latest" version of the docs, https://juliagizmos.github.io/GtkReactive.jl/latest/.)