### PR TITLE
RCF: better shortcut facilities

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -90,6 +90,7 @@ using .GConstants
 
 include("windows.jl")
 include("gl_area.jl")
+include("shortcuts.jl")
 
 # Alternative Interface (`using Gtk.ShortNames`)
 module ShortNames

--- a/src/basic_exports.jl
+++ b/src/basic_exports.jl
@@ -25,6 +25,9 @@ export add_events, signal_emit,
     on_signal_destroy, on_signal_button_press,
     on_signal_button_release, on_signal_motion
 
+#Shortcuts
+export Shortcut, doing
+
 # Gdk info and manipulation
 export screen_size
 

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -1,0 +1,72 @@
+get_default_mod_mask() = ccall((:gtk_accelerator_get_default_mod_mask , libgtk),
+    typeof(GdkModifierType.CONTROL),())
+
+@static if is_apple()
+    const PrimaryModifier = GdkModifierType.MOD2 #command key
+    const SecondaryModifer = GdkModifierType.CONTROL
+end
+@static if is_windows()
+    const PrimaryModifier = GdkModifierType.CONTROL
+    const SecondaryModifer = GdkModifierType.MOD1 #alt key
+end
+@static if is_linux()
+    const PrimaryModifier = GdkModifierType.CONTROL
+    const SecondaryModifer = GdkModifierType.MOD1
+end
+const NoModifier  = Base.zero(UInt32)
+
+"""
+Represents a combination of keys.
+
+##Examples:
+
+    Shortcut(GdkKeySyms.Tab) # Tab key
+
+    Shortcut("c") # c key
+
+    Shortcut("c",PrimaryModifier) # Ctrl-c (Windows & Linux) or Command-c (OS X)
+
+    Shortcut("C",PrimaryModifier + GdkModifierType.SHIFT) # Ctrl-Shit-c (notice the capital A)
+
+"""
+immutable Shortcut
+    keyval::UInt32
+    state::UInt32
+
+    Shortcut(k::Integer,s::Integer) = new(k,s)
+    Shortcut(k::Integer) = new(k,NoModifier)
+    Shortcut(k::AbstractString) = new(keyval(k),NoModifier)
+    Shortcut(k::AbstractString,s::Integer) = new(keyval(k),s)
+end
+
+"""
+    doing(s::Shortcut, event::GdkEvent)
+
+Test wether the `GdkEvent` corresponds to the given `Shortcut`.
+
+##Example:
+
+    if doing(Shortcut("c",PrimaryModifier),event)
+        #copy...
+    end
+
+Reference : https://developer.gnome.org/gtk3/unstable/checklist-modifiers.html
+
+"""
+function doing(s::Shortcut, event::GdkEvent)
+
+    mod = get_default_mod_mask()
+    #on os x, the command key is also the meta key
+    @static if is_apple()
+        if s.state == NoModifier && event.state == NoModifier
+             return event.keyval == s.keyval
+        end
+        if (event.keyval == s.keyval) && (event.state & mod == s.state)
+            return true
+        end
+        return (event.keyval == s.keyval) &&
+               (event.state & mod == s.state + GdkModifierType.META)
+    end
+
+    return (event.keyval == s.keyval) && (event.state & mod == s.state)
+end

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -26,7 +26,7 @@ Represents a combination of keys.
 
     Shortcut("c",PrimaryModifier) # Ctrl-c (Windows & Linux) or Command-c (OS X)
 
-    Shortcut("C",PrimaryModifier + GdkModifierType.SHIFT) # Ctrl-Shit-c (notice the capital A)
+    Shortcut("C",PrimaryModifier + GdkModifierType.SHIFT) # Ctrl-Shit-c (notice the capital C)
 
 """
 immutable Shortcut

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -44,4 +44,18 @@ destroy(win)
 
 @test isa(Gtk.GdkEventKey(), Gtk.GdkEventKey)
 
+# Shortcuts
+
+@test Shortcut("c").keyval == keyval("c")
+@test Shortcut("c",GConstants.GdkModifierType.CONTROL).state == GConstants.GdkModifierType.CONTROL
+
+win = GtkWindow()
+event = Gtk.GdkEventKey(GdkEventType.KEY_PRESS, Gtk.gdk_window(win),
+            Int8(0), UInt32(0), UInt32(0), Gtk.GdkKeySyms.Return, UInt32(0),
+            convert(Ptr{UInt8},C_NULL), UInt16(13), UInt8(0), UInt32(0) )
+
+@test doing(Shortcut(Gtk.GdkKeySyms.Return),event) == true
+@test doing(Shortcut(Gtk.GdkKeySyms.Return,Gtk.PrimaryModifier),event) == false
+destroy(win)
+
 end


### PR DESCRIPTION
This solves a couple of issues:

- It makes it a bit easier to create keyboard shortcuts and to check them against events.
- It checks correctly shortcuts, taking into account CapsLock and such.
- It introduce platform dependent Modifiers (PrimaryModifier and SecondaryModifer) so you can have consistent shortcuts between windows/linux and OS X (PrimaryModifier refers to Control on windows and Command on OS X).
- It checks correctly (I think) the Command key on OS X (which is also the Meta key by default).