### PR TITLE
Fix ambiguity in GLib convert methods

### DIFF
--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -277,11 +277,14 @@ macro quark_str(q)
 end
 
 unsafe_convert{T <: GBoxed}(::Type{Ptr{T}}, box::T) = convert(Ptr{T}, box.handle)
+convert(::Type{GBoxed}, boxed::GBoxed) = boxed
+convert(::Type{GBoxedUnkown}, boxed::GBoxedUnkown) = boxed
+convert{T <: GBoxed}(::Type{T}, boxed::T) = boxed
+convert{T <: GBoxed}(::Type{T}, boxed::GBoxed) = convert(T, boxed.handle)
 convert(::Type{GBoxed}, unbox::Ptr{GBoxed}) = GBoxedUnkown(unbox)
 convert{T <: GBoxed}(::Type{GBoxed}, unbox::Ptr{T}) = GBoxedUnkown(unbox)
 convert{T <: GBoxed}(::Type{T}, unbox::Ptr{GBoxed}) = convert(T, convert(Ptr{T}, unbox))
 convert{T <: GBoxed}(::Type{T}, unbox::Ptr{T}) = T(unbox)
-convert{T <: GBoxed}(::Type{T}, unbox::GBoxedUnkown) = convert(T, unbox.handle)
 
 # All GObjects are expected to have a 'handle' field
 # of type Ptr{GObject} corresponding to the GLib object

--- a/test/glib.jl
+++ b/test/glib.jl
@@ -20,6 +20,8 @@ repr = Base.print_to_string(wrap) #should display properties
 @test contains(repr,"title=NULL")
 @test contains(repr,"type=GTK_WINDOW_TOPLEVEL")
 
+@test isa(convert(Gtk.GLib.GBoxedUnkown, Gtk.GLib.GBoxedUnkown(C_NULL)), Gtk.GLib.GBoxedUnkown)
+
 end
 
 # TODO


### PR DESCRIPTION
Discovered this ambiguity while looking at #311. This doesn't fix it, but I thought one might as well fix the ambiguity.

There's still one more involving GList.