### PR TITLE
Fix deprecation warnings and typo corrections in docs

### DIFF
--- a/docs/src/manual/async.md
+++ b/docs/src/manual/async.md
@@ -7,11 +7,11 @@ to offload the work. The example is just a proof of principle.
 ```julia
 using Gtk
 
-btn = @GtkButton("Start")
-sp = @GtkSpinner()
-ent = @GtkEntry()
+btn = GtkButton("Start")
+sp = GtkSpinner()
+ent = GtkEntry()
 
-grid = @GtkGrid()
+grid = GtkGrid()
 grid[1,1] = btn
 grid[2,1] = sp
 grid[1:2,2] = ent
@@ -34,8 +34,8 @@ signal_connect(btn, "clicked") do widget
  end
 end
 
-win = @GtkWindow(grid, "Progress Bar", 200, 200)
+win = GtkWindow(grid, "Progress Bar", 200, 200)
 showall(win)
-``` 
+```
 
 

--- a/docs/src/manual/builder.md
+++ b/docs/src/manual/builder.md
@@ -1,32 +1,32 @@
 # Builder and Glade
 
 Until now we have created and arranged all widgets entirely using Julia code. While this works fine
-for small examples it has the issue that we are tighly coupling the appearance from our application
+for small examples, it has the issue that we are tightly coupling the appearance from our application
 with the logic of our program code. In addition the linear way of procedural Julia code does not fit
-very well with complex user interfaces arranged in deeple nested tables and boxes.
+very well with complex user interfaces arranged in deeply nested tables and boxes.
 
-Furtunately, there is a much better way to design user interfaces that strictly separated the layout 
+Fortunately, there is a much better way to design user interfaces that strictly separate the layout
 from the code. This is done by an XML based file format that allows for describing any widget
-arrangements. The XML file is usually not manually created but designed graphically using 
-[Glade](https://glade.gnome.org) in a WYSIWYG (what you see is what you get) manner. In order to use 
-the interface in your Julia Gtk application you will need `GtkBuilder` 
+arrangements. The XML file is usually not manually created but designed graphically using
+[Glade](https://glade.gnome.org) in a WYSIWYG (what you see is what you get) manner. In order to use
+the interface in your Julia Gtk application you will need `GtkBuilder`.
 
 ## Glade
 
-Glade lets you create complex user interfaces by graphically arranging them together in a user 
+Glade lets you create complex user interfaces by graphically arranging them together in a user
 friendly way. There are many good [tutorials](https://wiki.gnome.org/action/show/Apps/Glade/Tutorials)
 out there so that we will skip a detailed introduction here.
 
-The important thing when putting togther the interface with glade is to give each widget that you 
-later want to interface with a meaningful ID. 
+The important thing when putting together the interface with glade is to give each widget that you
+later want to interface with a meaningful ID.
 
 !!! note
-    Note that Glade can not only be used to create toplevel widgets (e.g. Windows). Instead one can 
+    Note that Glade can not only be used to create toplevel widgets (e.g. Windows). Instead one can
     start for instance with a `GtkGrid` or `GtkBox` serving as the base for a [Custom/Composed Widgets](@ref).
 
 ## Builder
 
-Once we have created the interface with Glade the result can be stored in an XML file that usually has 
+Once we have created the interface with Glade the result can be stored in an XML file that usually has
 the extension `.glade`. Lets assume we have created a file `myapp.glade` that looks like
 
 ```xml
@@ -49,12 +49,12 @@ the extension `.glade`. Lets assume we have created a file `myapp.glade` that lo
 </interface>
 ```
 
-In order to access the widgets from Julia we first create a `GtkBuilder` object that will serve as our 
+In order to access the widgets from Julia we first create a `GtkBuilder` object that will serve as our
 connector between the XML definition and our Julia code.
 ```julia
 b = @GtkBuilder(filename=myapp.glade)
 ```
-Alternatively, if we would store above XML definition in a Julia string `myapp` we can initalize 
+Alternatively, if we would store above XML definition in a Julia string `myapp` we can initalize
 the builder by
 ```julia
 b = @GtkBuilder(buffer=myapp)
@@ -65,16 +65,16 @@ we call
 win = b["window1"]
 showall(win)
 ```
-That is all that you need to know. You can thus see your builder as a kind of a widget store that you use 
+That is all that you need to know. You can thus see your builder as a kind of a widget store that you use
 when you need access to your widgets. It it therefore not really necessary to bind the widgets to local
 variables anymore but instead you can always use the builder object.
 
 !!! note
-    If you are developing the code in a package you can get the package directory using the `Pkg.dir("MyPackage")` 
-    function. This allows you to put the files into the package diretory and reference them in a relative manner.
+    If you are developing the code in a package you can get the package directory using the `Pkg.dir("MyPackage")`
+    function. This allows you to put the files into the package directory and reference them in a relative manner.
 
 ## Callbacks
 
-The XML file lets us only describe the visual structure of our widgets and not their behavior when the using 
+The XML file lets us only describe the visual structure of our widgets and not their behavior when the using
 is interacting with it. For this reason, we will have to add callbacks to the widgets which we do in Julia code
 as it was described in [Signals and Callbacks](@ref).

--- a/docs/src/manual/canvas.md
+++ b/docs/src/manual/canvas.md
@@ -5,7 +5,7 @@ Generic drawing is done on a `Canvas`. You control what appears on this canvas b
 ```julia
 using Gtk, Graphics
 c = @GtkCanvas()
-win = @GtkWindow(c, "Canvas")
+win = GtkWindow(c, "Canvas")
 @guarded draw(c) do widget
     ctx = getgc(c)
     h = height(c)

--- a/docs/src/manual/combobox.md
+++ b/docs/src/manual/combobox.md
@@ -13,7 +13,7 @@ listen on the `changed` event
 ```julia
 using Gtk
 
-cb = @GtkComboBoxText()
+cb = GtkComboBoxText()
 choices = ["one", "two", "three", "four"]
 for choice in choices
   push!(cb,choice)
@@ -30,7 +30,7 @@ signal_connect(cb, "changed") do widget, others...
   println("Active element is \"$str\" at index $idx")
 end
 
-win = @GtkWindow("ComboBoxText Example",400,200)
+win = GtkWindow("ComboBoxText Example",400,200)
 push!(win, cb)
 showall(win)
 ```

--- a/docs/src/manual/customWidgets.md
+++ b/docs/src/manual/customWidgets.md
@@ -1,8 +1,8 @@
 # Custom/Composed Widgets
 
-In practice one usually has to customize a widget to ones own needs. 
+In practice, one usually has to customize a widget to ones own needs.
 Furthermore, it is also useful to group widgets together to break up
-a comple user interface into manageble parts. Both use cases are discussed next.
+a complete user interface into manageable parts. Both use cases are discussed next.
 
 ## Custom Widgets
 
@@ -13,7 +13,7 @@ type MyButton <: Gtk.GtkButton
     handle::Ptr{Gtk.GObject}
     other_fields
     function MyButton(label)
-        btn = @GtkButton(label)
+        btn = GtkButton(label)
         return Gtk.gobject_move_ref(new(btn), btn)
     end
 end
@@ -29,24 +29,24 @@ type MyButton <: Gtk.GtkButton
     handle::Ptr{Gtk.GObject}
 
     function MyButton()
-        btn = @GtkButton("My Button")
+        btn = GtkButton("My Button")
         return Gtk.gobject_move_ref(new(btn.handle), btn)
     end
 end
 ```
 
-We can now add this button to e.g. a window or any layout container just as if `MyButton` would be be a regular `GtkWidget`.
+We can now add this button to e.g. a window or any layout container just as if `MyButton` would be a regular `GtkWidget`.
 
 ```julia
 btn = MyButton()
-win = @GtkWindow("Custom Widget",400,200)
+win = GtkWindow("Custom Widget",400,200)
 push!(win, btn)
 showall(win)
 ```
 
 ## Composed Widgets
 
-While a preinitialized button might look like an artificial use cases the same pattern can be used to develop composed widgets. In that case one will typically subclass from a layout widget such as `GtkBox` or `GtkGrid`. Lets for instance build a new composed widget consisting of a text box and a button
+While a pre-initialized button might look like an artificial use cases, the same pattern can be used to develop composed widgets. In that case one will typically subclass from a layout widget such as `GtkBox` or `GtkGrid`. Lets for instance build a new composed widget consisting of a text box and a button
 
 ```julia
 type ComposedWidget <: Gtk.GtkBox
@@ -55,9 +55,9 @@ type ComposedWidget <: Gtk.GtkBox
     tv # handle to child
 
     function ComposedWidget(label)
-        vbox = @GtkBox(:v)
-        btn = @GtkButton(label)
-        tv = @GtkTextView()
+        vbox = GtkBox(:v)
+        btn = GtkButton(label)
+        tv = GtkTextView()
         push!(vbox,btn,tv)
         setproperty!(vbox,:expand,tv,true)
         setproperty!(vbox,:spacing,10)
@@ -67,7 +67,7 @@ type ComposedWidget <: Gtk.GtkBox
 end
 
 c = ComposedWidget("My Button")
-win = @GtkWindow("Composed Widget",400,200)
+win = GtkWindow("Composed Widget",400,200)
 push!(win, c)
 showall(win)
 

--- a/docs/src/manual/gettingStarted.md
+++ b/docs/src/manual/gettingStarted.md
@@ -5,14 +5,14 @@ and adds a button to it
 ```julia
 using Gtk
 
-win = @GtkWindow("My First Gtk.jl Program", 400, 200)
+win = GtkWindow("My First Gtk.jl Program", 400, 200)
 
-b = @GtkButton("Click Me")
+b = GtkButton("Click Me")
 push!(win,b)
 
 showall(win)
 ```
-We will now go through this example step by step. First the package is loaded `using Gtk` statement. Then a window is created using the `@GtkWindow` macro. It gets as input the window title, the window width, and the window height. Then a button is created using the `@GtkButton` macro. In order to insert the button into the window we call 
+We will now go through this example step by step. First the package is loaded `using Gtk` statement. Then a window is created using the `GtkWindow` constructor. It gets as input the window title, the window width, and the window height. Then a button is created using the `GtkButton` constructor. In order to insert the button into the window we call
 ```julia
 push!(win,b)
 ```
@@ -34,9 +34,9 @@ Our full extended example thus looks like:
 ```julia
 using Gtk
 
-win = @GtkWindow("My First Gtk.jl Program", 400, 200)
+win = GtkWindow("My First Gtk.jl Program", 400, 200)
 
-b = @GtkButton("Click Me")
+b = GtkButton("Click Me")
 push!(win,b)
 
 function on_button_clicked(w)

--- a/docs/src/manual/keyevents.md
+++ b/docs/src/manual/keyevents.md
@@ -4,7 +4,7 @@ In order to capture a keyboard event one can connect to the `key-press-event` fr
 ```
 using Gtk
 
-win = @GtkWindow("Key Press Example")
+win = GtkWindow("Key Press Example")
 
 signal_connect(win, "key-press-event") do widget, event
   println("You pressed key ", event.keyval)

--- a/docs/src/manual/layout.md
+++ b/docs/src/manual/layout.md
@@ -3,17 +3,17 @@
 You will usually want to add more than one widget to you application. To this end, Gtk provides several layout widget. Instead of using a precise positioning, the Gtk layout widgets take an approach where widgets are aligned in boxes and tables.
 
 !!! note
-    While doing the layout using Julia code is possible for small examples it is in general adviced to instead create the layout using Glade in combination with GtkBuilder [Builder and Glade](@ref).
+    While doing the layout using Julia code is possible for small examples it is in general advised to instead create the layout using Glade in combination with GtkBuilder [Builder and Glade](@ref).
 
 ## Box
 
 The most simple layout widget is the `GtkBox`. It can be either be horizontally or vertical aligned. It allow to add an arbitrary number of widgets.
 ```julia
-win = @GtkWindow("New title")
-hbox = @GtkBox(:h)  # :h makes a horizontal layout, :v a vertical layout
+win = GtkWindow("New title")
+hbox = GtkBox(:h)  # :h makes a horizontal layout, :v a vertical layout
 push!(win, hbox)
-cancel = @GtkButton("Cancel")
-ok = @GtkButton("OK")
+cancel = GtkButton("Cancel")
+ok = GtkButton("OK")
 push!(hbox, cancel)
 push!(hbox, ok)
 showall(win)
@@ -42,12 +42,12 @@ The first line sets the `expand` property of the `ok` button within the `hbox` c
 
 More generally, you can arrange items in a grid:
 ```julia
-win = @Window("A new window")
-g = @Grid() 
-a = @Entry()  # a widget for entering text
+win = Window("A new window")
+g = Grid()
+a = Entry()  # a widget for entering text
 setproperty!(a, :text, "This is Gtk!")
-b = @CheckButton("Check me!")
-c = @Scale(false, 0:10)     # a slider
+b = CheckButton("Check me!")
+c = Scale(false, 0:10)     # a slider
 
 # Now let's place these graphical elements into the Grid:
 g[1,1] = a    # Cartesian coordinates, g[x,y]

--- a/docs/src/manual/listtreeview.md
+++ b/docs/src/manual/listtreeview.md
@@ -1,9 +1,9 @@
 # List and Tree Widgets
 
-The `GtkTreeView` is a very powerful widgets for displaying table-like or hierachical data.
+The `GtkTreeView` is a very powerful widgets for displaying table-like or hierarchical data.
 Other than the name might indicate the `GtkTreeView` is used for both lists and trees.
 
-The power of this widget comes with a slightly more complex design that one has to understand when 
+The power of this widget comes with a slightly more complex design that one has to understand when
 using the widget. The most important thing is that the widget itself does not store the displayed
 data. Instead there are dedicated `GtkListStore` and `GtkTreeStore` containers that will hold the data.
 The benefit of this approach is that it is possible to decouple the view from the data:
@@ -18,11 +18,11 @@ We will in the following introduce both widgets based on small and a more comple
 ## List Store
 
 Lets start with a very simple example: A table with three columns representing
-the name, the age and the gender of a person. Each column must have a specific type. 
+the name, the age and the gender of a person. Each column must have a specific type.
 Here, we chose to represent the gender using a boolean value where `true`  represents
 female and `false` represents male. We thus initialize the list store using
 ```julia
-ls = @GtkListStore(String, Int, Bool)
+ls = GtkListStore(String, Int, Bool)
 ```
 Now we will the store with data
 ```julia
@@ -54,20 +54,20 @@ julia> ls[1,1] = "Pete"
 
 Now we actually want to display our data. To this end we create a tree view object
 ```julia
-tv = @GtkTreeView(GtkTreeModel(ls))
+tv = GtkTreeView(GtkTreeModel(ls))
 ```
 Then we need specific renderers for each of the columns. Usually you will only
 need a text renderer, but in our example we want to display the boolean value
 using a checkbox.
 ```julia
-rTxt = @GtkCellRendererText()
-rTog = @GtkCellRendererToggle()
+rTxt = GtkCellRendererText()
+rTog = GtkCellRendererToggle()
 ```
 Finally we create for each column a `TreeViewColumn` object
 ```julia
-c1 = @GtkTreeViewColumn("Name", rTxt, Dict([("text",0)]))
-c2 = @GtkTreeViewColumn("Age", rTxt, Dict([("text",1)]))
-c3 = @GtkTreeViewColumn("Female", rTog, Dict([("active",2)]))
+c1 = GtkTreeViewColumn("Name", rTxt, Dict([("text",0)]))
+c2 = GtkTreeViewColumn("Age", rTxt, Dict([("text",1)]))
+c3 = GtkTreeViewColumn("Female", rTog, Dict([("active",2)]))
 ```
 We need to push these column description objects to the tree view
 ```julia
@@ -75,10 +75,10 @@ push!(tv, c1, c2, c3)
 ```
 Then we can display the tree view widget in a window
 ```julia
-win = @Window(tv, "List View")
+win = Window(tv, "List View")
 showall(win)
 ```
-If you prefer that the columns are resizeable by the user call
+If you prefer that the columns are resizable by the user call
 ```julia
 for (i,c) in enumerate([c1,c2,c3])
   GAccessor.resizable(c,true)
@@ -95,7 +95,7 @@ for (i,c) in enumerate([c1,c2,c3])
   GAccessor.sort_column_id(c,i-1)
 end
 ```
-I you now click on one of the column headers, the data will be sorted
+If you now click on one of the column headers, the data will be sorted
 with respect to the selected column. You can even make the columns reordarable
 ```julia
 for (i,c) in enumerate([c1,c2,c3])
@@ -114,13 +114,13 @@ One either have single selection or multiple selections. We toggle this by calli
 ```julia
 selection = GAccessor.mode(selection,Gtk.GConstants.GtkSelectionMode.MULTIPLE)
 ```
-We will stick with single selction for now and want to know the index of the
+We will stick with single selection for now and want to know the index of the
 selected item
 ```julia
 julia> ls[selected(selection),1]
 "Pete"
 ```
-Since it can happen that no item has been selected at all it is a good idea to
+Since it can happen that no item has been selected at all, it is a good idea to
 put this into an if statement
 ```julia
 if hasselection(selection)
@@ -138,7 +138,7 @@ signal_connect(selection, "changed") do widget
   end
 end
 ```
-Another usefull signal is "row-activated" that will be triggert by a double click
+Another useful signal is "row-activated" that will be triggered by a double click
 of the user.
 
 !!! note
@@ -148,12 +148,12 @@ of the user.
 
 A very useful thing is to apply a filter to a list view such that only a subset
 of data is shown. We can do this using the `GtkTreeModelFilter` type. It is
-as the `GtkListStore` a `GtkTreeModel` and therefore we can assign it to 
+as the `GtkListStore` a `GtkTreeModel` and therefore we can assign it to
 a tree view. So the idea is to wrap a `GtkListStore` in a `GtkTreeModelFilter` and
 assign that to the tree view.
 
 Next question is how to decide which row of the list store should be shown
-and which not. We will do this by adding an additional column to the list
+and which shouldn't. We will do this by adding an additional column to the list
 store that is hidden. The column will be of type `Bool` and a value `true` indicates
 that the entry is to be shown while `false` indicates the opposite.
 We make the filtering based on this column by a call to `GAccessor.visible_column`.
@@ -162,22 +162,22 @@ The full example now looks like this:
 ```julia
 using Gtk
 
-ls = @GtkListStore(String, Int, Bool, Bool)
+ls = GtkListStore(String, Int, Bool, Bool)
 push!(ls,("Peter",20,false,true))
 push!(ls,("Paul",30,false,true))
 push!(ls,("Mary",25,true,true))
 insert!(ls, 2, ("Susanne",35,true,true))
 
-rTxt = @GtkCellRendererText()
-rTog = @GtkCellRendererToggle()
+rTxt = GtkCellRendererText()
+rTog = GtkCellRendererToggle()
 
-c1 = @GtkTreeViewColumn("Name", rTxt, Dict([("text",0)]), sort_column_id=0)
-c2 = @GtkTreeViewColumn("Age", rTxt, Dict([("text",1)]), sort_column_id=1)
-c3 = @GtkTreeViewColumn("Female", rTog, Dict([("active",2)]), sort_column_id=2)
+c1 = GtkTreeViewColumn("Name", rTxt, Dict([("text",0)]), sort_column_id=0)
+c2 = GtkTreeViewColumn("Age", rTxt, Dict([("text",1)]), sort_column_id=1)
+c3 = GtkTreeViewColumn("Female", rTog, Dict([("active",2)]), sort_column_id=2)
 
-tmFiltered = @GtkTreeModelFilter(ls)
+tmFiltered = GtkTreeModelFilter(ls)
 GAccessor.visible_column(tmFiltered,3)
-tv = @GtkTreeView(GtkTreeModel(tmFiltered))
+tv = GtkTreeView(GtkTreeModel(tmFiltered))
 push!(tv, c1, c2, c3)
 
 selection = GAccessor.selection(tv)
@@ -186,31 +186,31 @@ signal_connect(selection, "changed") do widget
   if hasselection(selection)
     currentIt = selected(selection)
 
-    println("Name: ", GtkTreeModel(tmFiltered)[currentIt,1], 
+    println("Name: ", GtkTreeModel(tmFiltered)[currentIt,1],
             " Age: ", GtkTreeModel(tmFiltered)[currentIt,1])
   end
 end
 
-ent = @GtkEntry()
+ent = GtkEntry()
 
 signal_connect(ent, "changed") do widget
   searchText = getproperty(ent, :text, String)
-  
+
   for l=1:length(ls)
     showMe = true
 
-    if length(searchText) > 0 
+    if length(searchText) > 0
       showMe = showMe && contains(lowercase(ls[l,1]),lowercase(searchText))
-    end  
-    
+    end
+
     ls[l,4] = showMe
   end
 end
 
-vbox = @GtkBox(:v)
+vbox = GtkBox(:v)
 push!(vbox,ent,tv)
 
-win = @GtkWindow(vbox, "List View with Filter")
+win = GtkWindow(vbox, "List View with Filter")
 showall(win)
 ```
 You can see that we have added a little search bar such that you can see the
@@ -226,15 +226,15 @@ Here is an example of the tree model in action:
 ```julia
 using Gtk
 
-ts = @GtkTreeStore(String)
+ts = GtkTreeStore(String)
 iter1 = push!(ts,("one",))
 iter2 = push!(ts,("two",),iter1)
 iter3 = push!(ts,("three",),iter2)
-tv = @GtkTreeView(GtkTreeModel(ts))
-r1 = @GtkCellRendererText()
-c1 = @GtkTreeViewColumn("A", r1, Dict([("text",0)]))
+tv = GtkTreeView(GtkTreeModel(ts))
+r1 = GtkCellRendererText()
+c1 = GtkTreeViewColumn("A", r1, Dict([("text",0)]))
 push!(tv,c1)
-win = @GtkWindow(tv, "Tree View")
+win = GtkWindow(tv, "Tree View")
 showall(win)
 
 iter = Gtk.iter_from_index(ts, [1])

--- a/docs/src/manual/signals.md
+++ b/docs/src/manual/signals.md
@@ -8,8 +8,8 @@ to make something happen.
 
 Let's try a simple example:
 ```julia
-b = @Button("Press me")
-win = @Window(b, "Callbacks")
+b = Button("Press me")
+win = Window(b, "Callbacks")
 showall(win)
 
 function button_clicked_callback(widget)
@@ -28,8 +28,8 @@ the `"clicked"` signal.
 Using Julia's `do` syntax, the exact same code could alternatively be
 written as
 ```julia
-b = @Button("Press me")
-win = @Window(b, "Callbacks")
+b = Button("Press me")
+win = Window(b, "Callbacks")
 id = signal_connect(b, "clicked") do widget
      println(widget, " was clicked!")
 end
@@ -68,8 +68,8 @@ Alternatively, you can temporarily enable or disable individual handlers with `s
 The arguments of the callback depend on the signal type.
 For example, instead of using the `"clicked"` signal---for which the Julia handler should be defined with just a single argument---we could have used `"button-press-event"`:
 ```julia
-b = @Button("Pick a mouse button")
-win = @Window(b, "Callbacks")
+b = Button("Pick a mouse button")
+win = Window(b, "Callbacks")
 id = signal_connect(b, "button-press-event") do widget, event
     println("You pressed button ", event.button)
 end
@@ -82,7 +82,7 @@ keep in mind that you can always address other variables from inside your functi
 id = signal_connect((widget, event) -> cb_buttonpressed(widget, event, guistate, drawfunction, ...), b, "button-press-event")
 ```
 
-In some situations you may want or need to use an [approach that is more analagous to julia's `cfunction` callback syntax](doc/more_signals.md). One advantage of this alternative approach is that, in cases of error, the backtraces are much more informative.
+In some situations you may want or need to use an [approach that is more analogous to julia's `cfunction` callback syntax](doc/more_signals.md). One advantage of this alternative approach is that, in cases of error, the backtraces are much more informative.
 
 Warning: it is essential to avoid task switching inside Gtk callbacks,
 as this corrupts the Gtk C-stack. For example, use `@async print` or queue a message for yourself.

--- a/docs/src/manual/textwidgets.md
+++ b/docs/src/manual/textwidgets.md
@@ -6,10 +6,10 @@ displaying non-editable text `GtkLabel` the other is for editable text `GtkEntry
 ## Label
 
 A `GtkLabel` is the most basic text widget that has already been used behind the
-scene in any previous example involving a `GtkButton`. 
+scene in any previous example involving a `GtkButton`.
 A `GtkLabel` is constructed by calling
 ```julia
-label = @GtkLabel("My text")
+label = GtkLabel("My text")
 ```
 The text of a label can be changed using
 ```julia
@@ -46,7 +46,7 @@ Note that this will only happen, if the size of the widget is limited using layo
 
 The entry widget allows the user to enter text. The entered text can be read and write using
 ```julia
-ent = @GtkEntry()
+ent = GtkEntry()
 setproperty!(ent,:text,"My String")
 str = getproperty(ent,:text,String)
 ```
@@ -64,7 +64,7 @@ This can be achieve by calling
 ```julia
 setproperty!(ent,:visibility,false)
 ```
-To get notfied by changes to the entry one can listen the "changed" event.
+To get notified by changes to the entry one can listen the "changed" event.
 
 TODO: setting progress and setting icons in entry
 


### PR DESCRIPTION
As a new user to the package, I found a steady flow of deprecation warnings when running copy-pasta of the examples given in the docs. 

The warnings arise from [this commit](https://github.com/JuliaGraphics/Gtk.jl/commit/1a49e6bb7ff5b3daff8fab2f73b0fdbc18ba08d7), where `@Gtk...` is deprecated for `Gtk...` . 

This PR is so that the examples in the docs reflect the same.
Also included are a few typo fixes.