### PR TITLE
update gdk-pixbuf cache upon installation

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -52,6 +52,7 @@ if @compat is_apple()
             end
 	    ENV["GDK_PIXBUF_MODULEDIR"] = joinpath("$(Homebrew.brew_prefix)", "lib/gdk-pixbuf-2.0/2.10.0/loaders")
 	    ENV["GDK_PIXBUF_MODULE_FILE"] = joinpath("$(Homebrew.brew_prefix)", "lib/gdk-pixbuf-2.0/2.10.0/loaders.cache")
+	    run(`$(joinpath("$(Homebrew.brew_prefix)", "bin/gdk-pixbuf-query-loaders")) --update-cache`)
         end
         """)
     provides(Homebrew.HB, "glib", [glib, gio], os = :Darwin)


### PR DESCRIPTION
This should fix https://github.com/JuliaImages/ImageView.jl/issues/127 and #180. Not sure what's the best way to test whether this is working successfully since I had already fixed this error locally.

