### PR TITLE
Change 'gnome-icon-theme' to 'adwaita-icon-theme'

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -56,7 +56,7 @@ if @compat is_apple()
         """)
     provides(Homebrew.HB, "glib", [glib, gio], os = :Darwin)
     provides(Homebrew.HB, "gdk-pixbuf", gdk_pixbuf, os = :Darwin)
-    Homebrew.add("gnome-icon-theme")
+    Homebrew.add("adwaita-icon-theme")
 end
 
 @BinDeps.install Dict([


### PR DESCRIPTION
Running `Pkg.build("Gtk")` was failing on the line `Homebrew.add("gnome-icon-theme")`. Apparently the formula `gnome-icon-theme` was renamed to `adwaita-icon-theme` (see [this commit](https://github.com/Homebrew/homebrew-core/commit/0bcd2729c920a0e4c46a13f2d3f75b8a1889a8d8)).

After the proposed change everything works again.