### PR TITLE
fixed some macro-related deprecation warnings in documentation

### DIFF
--- a/docs/src/manual/builder.md
+++ b/docs/src/manual/builder.md
@@ -52,12 +52,12 @@ the extension `.glade`. Lets assume we have created a file `myapp.glade` that lo
 In order to access the widgets from Julia we first create a `GtkBuilder` object that will serve as our
 connector between the XML definition and our Julia code.
 ```julia
-b = @GtkBuilder(filename=myapp.glade)
+b = GtkBuilder(filename=myapp.glade)
 ```
 Alternatively, if we would store above XML definition in a Julia string `myapp` we can initalize
 the builder by
 ```julia
-b = @GtkBuilder(buffer=myapp)
+b = GtkBuilder(buffer=myapp)
 ```
 Now we want to access a widget from the XML file in order to actually display it on the screen. To do so
 we call

--- a/docs/src/manual/filedialogs.md
+++ b/docs/src/manual/filedialogs.md
@@ -18,7 +18,7 @@ You can specify multiple match types for a single filter by separating the patte
 You can alternatively specify MIME types, or if no specification is provided it defaults to types supported by `GdkPixbuf`.
 The generic specification of a filter is
 ```julia
-@FileFilter(; name = nothing, pattern = "", mimetype = "")
+FileFilter(; name = nothing, pattern = "", mimetype = "")
 ```
 
 If on the other hand you want to choose a folder instead of a file, set the `action` to `GtkFileChooserAction.SELECT_FOLDER`:
@@ -35,9 +35,9 @@ open_dialog("Pick a file")
 open_dialog("Pick some files", select_multiple=true)
 open_dialog("Pick a file", Null(), ("*.jl",))
 open_dialog("Pick some text files", GtkNullContainer(), ("*.txt,*.csv",), select_multiple=true)
-open_dialog("Pick a file", Null(), (@FileFilter(mimetype="text/csv"),))
-open_dialog("Pick an image file", GtkNullContainer(), ("*.png", "*.jpg", @FileFilter("*.png,*.jpg", name="All supported formats")))
-open_dialog("Pick an image file", GtkNullContainer(), (@FileFilter(name="Supported image formats"),))
+open_dialog("Pick a file", Null(), (FileFilter(mimetype="text/csv"),))
+open_dialog("Pick an image file", GtkNullContainer(), ("*.png", "*.jpg", FileFilter("*.png,*.jpg", name="All supported formats")))
+open_dialog("Pick an image file", GtkNullContainer(), (FileFilter(name="Supported image formats"),))
 
-save_dialog("Save as...", Null(), (@FileFilter("*.png,*.jpg", name="All supported formats"), "*.png", "*.jpg"))
+save_dialog("Save as...", Null(), (FileFilter("*.png,*.jpg", name="All supported formats"), "*.png", "*.jpg"))
 ```

--- a/docs/src/manual/nonreplusage.md
+++ b/docs/src/manual/nonreplusage.md
@@ -3,7 +3,7 @@
 If you're using Gtk from command-line scripts, one problem you may encounter is that Julia quits before you have a chance to see or interact with your windows. In such cases, the following design pattern can be helpful:
 
 ```julia
-win = @Window("gtkwait")
+win = Window("gtkwait")
 
 # Put your GUI code here
 


### PR DESCRIPTION
Some of the examples in the documentation at [https://juliagraphics.github.io/Gtk.jl/latest/index.html](https://juliagraphics.github.io/Gtk.jl/latest/index.html) still used deprecated macros.