### PR TITLE
Add waitforsignal(widget,signal) function

### DIFF
--- a/src/events.jl
+++ b/src/events.jl
@@ -207,3 +207,12 @@ function pop!(mh_evt::MHPair)
     end
     mh
 end
+
+
+function waitforsignal(widget,signal)
+  c = Condition()
+  signal_connect(widget, signal) do w
+      notify(c)
+  end
+  wait(c)
+end


### PR DESCRIPTION
Convenience function useful for things like stepping through procedural code one button click at a time, blocking a component until something specific happens, or keeping Julia from exiting when in interactive mode.

In the last (very common) usecase, it basically just wraps the snippet inside the if block at http://juliagraphics.github.io/Gtk.jl/latest/manual/nonreplusage.html into a function.