### PR TITLE
switch `build.jl` to use libgtk-3-dev from apt

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,7 +17,7 @@ deps = [
 ]
 
 if @compat is_linux()
-    provides(AptGet, "libgtk-3-0", deps)
+    provides(AptGet, "libgtk-3-dev", deps)
     provides(Yum, "gtk3", deps)
 end
 


### PR DESCRIPTION
Resolves #289 

To verify that this works, I created a new Dockerfile based on [docker-library/julia](https://github.com/docker-library/julia/blob/06148bd09222645c2996f50094d76aeeb9ed4556/Dockerfile ) which you can find here: https://gist.github.com/rdeits/b92935c572f9d057d7121c904e2c8040 The dockerfile has no gtk packages pre-installed, but builds Gtk.jl successfully after this change. 

I've tested the Docker build on Ubuntu 14.04, 16.04, and 17.10 along with Debian Jessie.

If you'd like, I can set up the Docker build as an additional build on Travis so this will get tested in the future.  
