### PR TITLE
Fix index_from_iter parsing wrongly

### DIFF
--- a/src/lists.jl
+++ b/src/lists.jl
@@ -124,7 +124,7 @@ GtkListStoreLeaf(combo::GtkComboBoxText) = GtkListStoreLeaf(ccall((:gtk_combo_bo
 
 ## index is integer for a liststore, vector of ints for tree
 iter_from_index(store::GtkListStore, index::Int) = iter_from_string_index(store, string(index - 1))
-index_from_iter(store::GtkListStore, iter::TRI) = Int(get_string_from_iter(GtkTreeModel(store), iter)) + 1
+index_from_iter(store::GtkListStore, iter::TRI) = parse(Int, get_string_from_iter(GtkTreeModel(store), iter)) + 1
 
 function list_store_set_values(store::GtkListStore, iter, values)
     for (i, value) in enumerate(values)

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -609,6 +609,7 @@ selmodel = G_.selection(tv)
 select!(selmodel, Gtk.iter_from_index(ls, 1))
 @test hasselection(selmodel) == true
 iter = selected(selmodel)
+@test Gtk.index_from_iter(ls, iter) == 1
 @test ls[iter, 1] == 44
 deleteat!(ls, iter)
 @test isvalid(ls, iter) == false


### PR DESCRIPTION
The same as #343, but with the requested test added.

Fixes #337 and closes #343.