### PR TITLE
Drop support for Julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
-julia 0.5
+julia 0.6
 Cairo 0.2.2
 Graphics 0.1
 BinDeps
 @windows WinRPM
 @osx Homebrew
-Compat 0.18
+Compat 0.66.0

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,7 +26,7 @@ makedocs(
 )
 
 deploydocs(repo   = "github.com/JuliaGraphics/Gtk.jl.git",
-           julia  = "0.5",
+           julia  = "0.6",
            target = "build",
            deps   = nothing,
            make   = nothing)

--- a/src/GLib/MutableTypes.jl
+++ b/src/GLib/MutableTypes.jl
@@ -2,7 +2,7 @@ module MutableTypes
 using Compat
 export mutable, Mutable, deref
 
-@compat abstract type Mutable{T} end
+abstract type Mutable{T} end
 type MutableX{T} <: Mutable{T}
     x::T
     (::Type{MutableX{T}}){T}() = new{T}()
@@ -12,7 +12,7 @@ immutable MutableA{T, N} <: Mutable{T}
     x::Array{T, N}
     i::Int
 end
-@compat const  MutableV{T} = MutableA{T, 1}
+const  MutableV{T} = MutableA{T, 1}
 
 mutable{T}(x::T) = MutableX{T}(x)
 mutable(x::Mutable) = x

--- a/src/GLib/glist.jl
+++ b/src/GLib/glist.jl
@@ -4,7 +4,7 @@
 
 ### an _LList is expected to have a data::Ptr{T} and next::Ptr{_LList{T}} element
 ### they are expected to be allocated and freed by GLib (e.g. with malloc/free)
-@compat abstract type _LList{T} end
+abstract type _LList{T} end
 
 immutable _GSList{T} <: _LList{T}
     data::Ptr{T}
@@ -34,7 +34,7 @@ end
 GList{T}(list::Type{T}) = GList(convert(Ptr{_GList{T}}, C_NULL), true)
 GList{L <: _LList}(list::Ptr{L}, transfer_full::Bool = false) = GList{L, eltype(L)}(list, transfer_full)
 
-@compat const  LList{L <: _LList} = Union{Ptr{L}, GList{L}}
+const  LList{L <: _LList} = Union{Ptr{L}, GList{L}}
 eltype{L <: _LList}(::LList{L}) = eltype(L)
 
 _listdatatype{T}(::Type{_LList{T}}) = T
@@ -52,7 +52,7 @@ start{L}(list::LList{L}) = unsafe_convert(Ptr{L}, list)
 next{T}(::LList, s::Ptr{T}) = (deref(s), unsafe_load(s).next) # return (value, state)
 done(::LList, s::Ptr) = (s == C_NULL)
 
-@compat const  LListPair{L} = Tuple{LList, Ptr{L}}
+const  LListPair{L} = Tuple{LList, Ptr{L}}
 function glist_iter{L <: _LList}(list::Ptr{L}, transfer_full::Bool = false)
     # this function pairs every list element with the list head, to forestall garbage collection
     return (GList(list, transfer_full), list)

--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -1,6 +1,6 @@
-@compat abstract type GObject end
-@compat abstract type GInterface <: GObject end
-@compat abstract type GBoxed  end
+abstract type GObject end
+abstract type GInterface <: GObject end
+abstract type GBoxed  end
 type GBoxedUnkown <: GBoxed
     handle::Ptr{GBoxed}
 end
@@ -169,7 +169,7 @@ function get_itype_decl(iname::Symbol, gtyp::GType)
             const $(esc(iname)) = gtype_abstracts[$(QuoteNode(iname))]
         else
             $piface_decl
-            @compat abstract type $(esc(iname)) <: $(esc(piname)) end
+            abstract type $(esc(iname)) <: $(esc(piname)) end
             gtype_abstracts[$(QuoteNode(iname))] = $(esc(iname))
         end
         nothing

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -26,7 +26,7 @@ import .Graphics: width, height, getgc
 using Cairo
 import Cairo: destroy
 
-@compat const Index{I<:Integer} = Union{I, AbstractVector{I}}
+const Index{I<:Integer} = Union{I, AbstractVector{I}}
 
 export GAccessor
 include("basic_exports.jl")

--- a/src/container.jl
+++ b/src/container.jl
@@ -18,7 +18,7 @@ function append!(w::GtkContainer, children)
     end
     w
 end
-@compat Base.:|>(parent::GtkContainer, child::Union{GObject, AbstractString}) = push!(parent, child)
+Base.:|>(parent::GtkContainer, child::Union{GObject, AbstractString}) = push!(parent, child)
 
 start(w::GtkContainer) = glist_iter(ccall((:gtk_container_get_children, libgtk), Ptr{_GList{GObject}}, (Ptr{GObject},), w))
 next(w::GtkContainer, list) = next(list[1], list)

--- a/src/gdk.jl
+++ b/src/gdk.jl
@@ -67,7 +67,7 @@ baremodule GdkKeySyms
     const KP_Enter = 0xff8d
 end
 
-@compat abstract type GdkEvent <: GBoxed end
+abstract type GdkEvent <: GBoxed end
 make_gvalue(GdkEvent, Ptr{GdkEvent}, :boxed, (:gdk_event, :libgdk))
 function convert(::Type{GdkEvent}, evt::Ptr{GdkEvent})
     e = unsafe_load(convert(Ptr{GdkEventAny}, evt))

--- a/src/text.jl
+++ b/src/text.jl
@@ -178,24 +178,24 @@ function setproperty!(text::Mutable{GtkTextIter}, key::Symbol, value)
     end
     return text
 end
-@compat(Base.:(==))(lhs::TI, rhs::TI) = Bool(ccall((:gtk_text_iter_equal, libgtk),
+Base.:(==)(lhs::TI, rhs::TI) = Bool(ccall((:gtk_text_iter_equal, libgtk),
     Cint, (Ptr{GtkTextIter}, Ptr{GtkTextIter}), mutable(lhs), mutable(rhs)))
-@compat(Base.:(!=))(lhs::TI, rhs::TI) = !(lhs == rhs)
-@compat(Base.:(<))(lhs::TI, rhs::TI) = ccall((:gtk_text_iter_compare, libgtk), Cint,
+Base.:(!=)(lhs::TI, rhs::TI) = !(lhs == rhs)
+Base.:(<)(lhs::TI, rhs::TI) = ccall((:gtk_text_iter_compare, libgtk), Cint,
     (Ptr{GtkTextIter}, Ptr{GtkTextIter}), mutable(lhs), mutable(rhs)) < 0
-@compat(Base.:(<=))(lhs::TI, rhs::TI) = ccall((:gtk_text_iter_compare, libgtk), Cint,
+Base.:(<=)(lhs::TI, rhs::TI) = ccall((:gtk_text_iter_compare, libgtk), Cint,
     (Ptr{GtkTextIter}, Ptr{GtkTextIter}), mutable(lhs), mutable(rhs)) <= 0
-@compat(Base.:(>))(lhs::TI, rhs::TI) = ccall((:gtk_text_iter_compare, libgtk), Cint,
+Base.:(>)(lhs::TI, rhs::TI) = ccall((:gtk_text_iter_compare, libgtk), Cint,
     (Ptr{GtkTextIter}, Ptr{GtkTextIter}), mutable(lhs), mutable(rhs)) > 0
-@compat(Base.:(>=))(lhs::TI, rhs::TI) = ccall((:gtk_text_iter_compare, libgtk), Cint,
+Base.:(>=)(lhs::TI, rhs::TI) = ccall((:gtk_text_iter_compare, libgtk), Cint,
     (Ptr{GtkTextIter}, Ptr{GtkTextIter}), mutable(lhs), mutable(rhs)) >= 0
 start(iter::TI) = mutable(iter)
 function next(::TI, iter::Mutable{GtkTextIter})
     (getproperty(iter, :char)::Char, iter + 1)
 end
 done(::TI, iter) = getproperty(iter, :is_end)::Bool
-@compat(Base.:+)(iter::TI, count::Integer) = (iter = mutable(copy(iter)); skip(iter, count); iter)
-@compat(Base.:-)(iter::TI, count::Integer) = (iter = mutable(copy(iter)); skip(iter, -count); iter)
+Base.:+(iter::TI, count::Integer) = (iter = mutable(copy(iter)); skip(iter, count); iter)
+Base.:-(iter::TI, count::Integer) = (iter = mutable(copy(iter)); skip(iter, -count); iter)
 Base.skip(iter::Mutable{GtkTextIter}, count::Integer) =
     Bool(ccall((:gtk_text_iter_forward_chars, libgtk), Cint,
         (Ptr{GtkTextIter}, Cint), iter, count))


### PR DESCRIPTION
Julia 0.5 has been declared officially unmaintained, so [package updates won't be accepted if they support this version](https://github.com/JuliaLang/METADATA.jl/pull/12729). This led to JuliaLang/METADATA.jl#14843 getting rejected. This PR makes 0.6 the minimum required julia version and removes compat macros that aren't needed anymore.