### PR TITLE
Update section 'Builder and Glade' of documentation

### DIFF
--- a/docs/src/manual/builder.md
+++ b/docs/src/manual/builder.md
@@ -52,7 +52,7 @@ the extension `.glade`. Lets assume we have created a file `myapp.glade` that lo
 In order to access the widgets from Julia we first create a `GtkBuilder` object that will serve as our
 connector between the XML definition and our Julia code.
 ```julia
-b = GtkBuilder(filename=myapp.glade)
+b = GtkBuilder(filename="path/to/myapp.glade")
 ```
 Alternatively, if we would store above XML definition in a Julia string `myapp` we can initalize
 the builder by


### PR DESCRIPTION
Only minor fixes here:
* Add missing quotes to the file path.
* The note on `Pkg.dir("MyPackage")` should maybe also be modified to reflect the fact that it is deprecated in 1.0. I am not sure which replacement is best here, though. I tend to use `@__DIR__` a lot, but the deprecation warning recommends using `joinpath(dirname(pathof(MyPackage)), "..", paths...)` instead. I have *not* changed the note.