### PR TITLE
Fix examples

### DIFF
--- a/example/2048.jl
+++ b/example/2048.jl
@@ -5,6 +5,7 @@ https://gaming.youtube.com/game/UCkIzbSwpjk5eRRNaZPxTy2w
 This example includes use of the Toolbar and Grid features of Gtk.jl.
 ========================================================================#
 
+using Gtk
 using Gtk.ShortNames
 
 @enum Direction2048 Right Left Up Down
@@ -87,7 +88,7 @@ function app2048(bsize)
     map(w->push!(toolbar,w),[newgame,undomove])
     grid = Grid()
     map(w -> push!(box, w),[toolbar, grid])
-    buttons = Array{Gtk.GtkButtonLeaf,2}(bsize, bsize)
+    buttons = Array{Gtk.GtkButtonLeaf,2}(undef, bsize, bsize)
     for i in 1:bsize, j in 1:bsize
         grid[i,j] = buttons[i,j] = Button()
         set_gtk_property!(buttons[i,j], :expand, true)

--- a/example/gl-area.jl
+++ b/example/gl-area.jl
@@ -1,6 +1,4 @@
-importall Gtk
-using Gtk.@Window
-using Gtk.@GLArea
+using Gtk
 using Gtk.GConstants
 
 function resize_event(widget::Gtk.GtkGLArea, width::Int32, height::Int32)
@@ -27,7 +25,7 @@ function button_release_event(widget::Gtk.GtkGLArea, event::Gtk.GdkEventButton)
 	return true
 end
 
-area = @GLArea()
+area = Gtk.GLArea()
 add_events(area,
 			GConstants.GdkEventMask.SCROLL |
 			GConstants.GdkEventMask.BUTTON_PRESS |
@@ -40,7 +38,7 @@ signal_connect(motion_notify_event, area, "motion-notify-event")
 signal_connect(button_press_event, area, "button-press-event")
 signal_connect(button_release_event, area, "button-release-event")
 
-win = @Window("Hello Gtk.jl")
+win = Gtk.Window("Hello Gtk.jl")
 push!(win, area)
 showall(win)
 


### PR DESCRIPTION
I tried to fix the examples to run in Julia 0.7, 1.0.
Some remaining annoying things.

* 2048.jl
  -  Got the following message on`info_dialog`
 ```Gtk-Message: 13:40:21.376: GtkDialog mapped without a transient parent. This is discouraged.```

* gl-area.jl
  - Displayed the text `Not implemented on OS X` on GLArea in my mac OSX. I can't find where it has to be.