### PR TITLE
Fix build.jl on Windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -22,7 +22,7 @@ if Sys.islinux()
 end
 
 if Sys.iswindows()
-    using WinRPM
+    using Pkg, WinRPM
     provides(WinRPM.RPM,"libgtk-3-0", [gtk,gdk,gdk_pixbuf,glib,gio], os = :Windows)
     provides(WinRPM.RPM,"libgobject-2_0-0", [gobject], os = :Windows)
 


### PR DESCRIPTION
`Pkg` now has to be explicitly imported to be used.