### PR TITLE
Added cross reference to explicit signal connect to make it easier for newbies to use 'row-activated'

### DIFF
--- a/doc/more_signals.md
+++ b/doc/more_signals.md
@@ -4,7 +4,7 @@ In addition to the ["simple"
 interface](../README.md#callbacks-and-signals), `signal_connect`
 supports an approach that allows your callback function to be directly
 compiled to machine code.  Not only is this more efficient, but it can
-occasionally be useful in avoiding problems (see issue #161).
+occasionally be useful in avoiding problems (see issue [#161](https://github.com/JuliaGraphics/Gtk.jl/issues/161)).
 
 This alternative syntax is as follows:
 ```

--- a/docs/src/manual/listtreeview.md
+++ b/docs/src/manual/listtreeview.md
@@ -139,7 +139,7 @@ signal_connect(selection, "changed") do widget
 end
 ```
 Another useful signal is "row-activated" that will be triggered by a double click
-of the user.
+of the user. Since it involves handling additional arguments, currently you'll need to use the [explicit signal connect](../../../doc/more_signals.md) (see also Issue [#405](https://github.com/JuliaGraphics/Gtk.jl/issues/405)).
 
 !!! note
     getting multiple selections still not implemented.


### PR DESCRIPTION
Since I had the issue myself in #405 and there doesn't seem to be any link between the rendered documentation and the /doc folder  figured this might help future users. (might be an idea to add the (doc folder to the manual in any case? or at least as a "further reading link?)