### PR TITLE
Make length() return Int instead of Int32.

### DIFF
--- a/src/lists.jl
+++ b/src/lists.jl
@@ -191,8 +191,10 @@ isvalid(listStore::GtkListStore, iter::TRI) =
     ccall((:gtk_list_store_iter_is_valid, libgtk), Cint,
          (Ptr{GObject}, Ref{GtkTreeIter}), listStore, iter) != 0
 
-length(listStore::GtkListStore) =
-    ccall((:gtk_tree_model_iter_n_children, libgtk), Cint, (Ptr{GObject}, Ptr{GtkTreeIter}), listStore, C_NULL)
+function length(listStore::GtkListStore)
+    _len = ccall((:gtk_tree_model_iter_n_children, libgtk), Cint, (Ptr{GObject}, Ptr{GtkTreeIter}), listStore, C_NULL)
+	return convert(Int, _len)
+end
 
 size(listStore::GtkListStore) = (length(listStore), ncolumns(GtkTreeModel(listStore)))
 


### PR DESCRIPTION
`pop!(::GtkListStoreLeaf)` uses `length(::GtkListStore)` which currently returns an `Int32` instead of an `Int`.

It then calls `deleteat!(...)` which expects an index of type `Int` (thus failing to match signature when called with `Int32`).

I am pretty certain that we don't want to "loosen" `deleteat!(...)` to take in `Integer` types... so I instead ensure the output of `length()` is of type `Int`.