### PR TITLE
Update docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: julia
+coveralls: true
 sudo: required
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ addons:
       - xvfb
       - xauth
       - libgtk-3-dev
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 jobs:
   include:
     - stage: "Documentation"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@ language: julia
 sudo: required
 os:
   - linux
-  #- osx
+  - osx
 julia:
   - 0.7
   - 1.0
   - 1.2
   - nightly
-# uncomment the following lines to allow failures on nightly julia
 # (tests will run but not make your overall status red)
 matrix:
   allow_failures:
     - julia: nightly
+    - os: osx
 notifications:
   email: false
 git:
@@ -27,6 +27,15 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
   - $TESTCMD -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'import Pkg; Pkg.instantiate(); Pkg.develop(Pkg.PackageSpec(path=pwd()))'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip
 after_success:
   - julia -e 'using Pkg;
               import Gtk;
@@ -36,7 +45,7 @@ after_success:
               Coveralls.submit(Coveralls.process_folder())'
   # update the documentation
   - julia -e 'using Pkg;
-              ps=Pkg.PackageSpec(name="Documenter", version="0.19");
+              ps=Pkg.PackageSpec(name="Documenter");
               Pkg.add(ps);
               Pkg.pin(ps)'
   - $TESTCMD -e 'using Pkg;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ os:
 julia:
   #- 0.7
   - 1.0
-  #- 1.2
-  #- nightly
-# (tests will run but not make your overall status red)
+  - 1.2
+  - nightly
 matrix:
   allow_failures:
     - julia: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 sudo: required
 os:
   - linux
-  #- osx
+  - osx
 julia:
   #- 0.7
   - 1.0
@@ -23,10 +23,6 @@ addons:
       - xvfb
       - xauth
       - libgtk-3-dev
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
-  - $TESTCMD -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 jobs:
   include:
     - stage: "Documentation"
@@ -36,20 +32,3 @@ jobs:
         - julia --project=docs/ -e 'import Pkg; Pkg.instantiate(); Pkg.develop(Pkg.PackageSpec(path=pwd()))'
         - julia --project=docs/ docs/make.jl
       after_success: skip
-after_success:
-  - julia -e 'using Pkg;
-              import Gtk;
-              cd(joinpath(dirname(pathof(Gtk))));
-              Pkg.add("Coverage");
-              using Coverage;
-              Coveralls.submit(Coveralls.process_folder())'
-  # update the documentation
-  - julia -e 'using Pkg;
-              ps=Pkg.PackageSpec(name="Documenter");
-              Pkg.add(ps);
-              Pkg.pin(ps)'
-  - $TESTCMD -e 'using Pkg;
-                 import Gtk;
-                 cd(joinpath(dirname(pathof(Gtk))));
-                 ENV["DOCUMENTER_DEBUG"] = "true";
-                 include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: julia
-coveralls: true
 sudo: required
 os:
   - linux
@@ -27,6 +26,8 @@ addons:
       - libgtk-3-dev
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
+  - $TESTCMD -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 jobs:
   include:
     - stage: "Documentation"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: julia
 sudo: required
 os:
   - linux
-  - osx
+  #- osx
 julia:
-  - 0.7
+  #- 0.7
   - 1.0
-  - 1.2
-  - nightly
+  #- 1.2
+  #- nightly
 # (tests will run but not make your overall status red)
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
   allow_failures:
     - julia: nightly
     - os: osx
+    - stage: "Documentation" # This shouldn't be necessary
 notifications:
   email: false
 git:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"


### PR DESCRIPTION
As @jonathanBieler pointed out in https://github.com/JuliaGraphics/Gtk.jl/pull/438#issuecomment-534022823 build passes but docs update fails.

I think `.travis.yml` needs a cleanup. Documenter.jl was pinned to v0.19