### PR TITLE
add macro idle_add

### DIFF
--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -20,7 +20,7 @@ export GEnum, GError, GValue, gvalue, make_gvalue, @make_gvalue, g_type
 export GList, glist_iter, _GSList, _GList, gobject_ref, gobject_move_ref
 export signal_connect, signal_emit, signal_handler_disconnect
 export signal_handler_block, signal_handler_unblock
-export g_timeout_add, g_idle_add
+export g_timeout_add, g_idle_add, @idle_add
 export set_gtk_property!, get_gtk_property
 export GConnectFlags
 export @sigatom, cfunction_

--- a/src/GLib/signals.jl
+++ b/src/GLib/signals.jl
@@ -381,6 +381,16 @@ end
 
 @deprecate g_idle_add(cb, user_data)  g_idle_add(() -> cb(user_data))
 
+# Shortcut for g_idle_add
+macro idle_add(ex)
+    quote
+    g_idle_add() do
+        $(esc(ex))
+        return false
+      end
+    end
+end
+
 const exiting = Ref(false)
 function __init__()
     if isdefined(GLib, :__init__bindeps__)

--- a/src/base.jl
+++ b/src/base.jl
@@ -41,7 +41,7 @@ grab_focus(w::GtkWidget) = (@sigatom ccall((:gtk_widget_grab_focus , libgtk), Cv
 modifyfont(w::GtkWidget, font_desc::Ptr{Nothing}) =
    ccall((:gtk_widget_modify_font, libgtk), Nothing, (Ptr{GObject}, Ptr{Nothing}), w, font_desc)
 
-   
+
 function get_gtk_property(w::GtkContainer, name::AbstractStringLike, child::GtkWidget, ::Type{T}) where T
     v = gvalue(T)
     ccall((:gtk_container_child_get_property, libgtk), Nothing,
@@ -99,6 +99,8 @@ function _guarded(ex, retval)
         end
     end
 end
+
+
 
 
 @deprecate getindex(w::GtkContainer, child::GtkWidget, name::AbstractStringLike, T::Type) get_gtk_property(w, name, child, T)

--- a/src/basic_exports.jl
+++ b/src/basic_exports.jl
@@ -32,7 +32,7 @@ export add_events, signal_emit,
 # Gdk info and manipulation
 export screen_size
 
-export @guarded, @sigatom
+export @guarded, @sigatom, @idle_add
 
 # Tk-compatibility (reference of potentially missing functionality):
 #export Frame, Labelframe, Notebook, Panedwindow

--- a/test/glib.jl
+++ b/test/glib.jl
@@ -29,19 +29,19 @@ function g_timeout_add_cb()
     false
 end
 
-Gtk.GLib.g_idle_add(g_timeout_add_cb)
+g_idle_add(g_timeout_add_cb)
 sleep(0.5)
 @test x[] == 2
 
 x[] = 1 #reset
-Gtk.GLib.g_timeout_add(g_timeout_add_cb, 1)
+g_timeout_add(g_timeout_add_cb, 1)
 sleep(0.5)
 @test x[] == 2
 
 # do syntax
 
 x[] = 1 #reset
-Gtk.GLib.g_idle_add() do
+g_idle_add() do
   x[] = 2
   return false # only call once
 end
@@ -49,9 +49,18 @@ sleep(0.5)
 @test x[] == 2
 
 x[] = 1 #reset
-Gtk.GLib.g_timeout_add(1) do
+g_timeout_add(1) do
   x[] = 2
   return false # only call once
+end
+sleep(0.5)
+@test x[] == 2
+
+# macro syntax
+
+x[] = 1 #reset
+@idle_add begin
+  x[] = 2
 end
 sleep(0.5)
 @test x[] == 2
@@ -64,12 +73,12 @@ function g_timeout_add_cb(user_data)
 end
 
 x[] = 1 #reset
-Gtk.GLib.g_idle_add(()->g_timeout_add_cb(x))
+g_idle_add(()->g_timeout_add_cb(x))
 sleep(0.5)
 @test x[] == 2
 
 x[] = 1 #reset
-Gtk.GLib.g_timeout_add(()->g_timeout_add_cb(x), 1)
+g_timeout_add(()->g_timeout_add_cb(x), 1)
 sleep(0.5)
 @test x[] == 2
 


### PR DESCRIPTION
This is a macro that simplifies usage of `g_idle_add` a little bit. This may now be a drop-in replacement for `@sigatom`. Not sure if we actually still need that.