### PR TITLE
Usage of Gtk on windows needs a warning

### DIFF
--- a/src/events.jl
+++ b/src/events.jl
@@ -12,7 +12,10 @@ function __init__()
             (Ptr{Nothing}, Ptr{Nothing}, Ptr{UInt8}, Ptr{Nothing}, Ptr{UInt8}, Ptr{GError}),
             C_NULL, C_NULL, "Julia Gtk Bindings", C_NULL, C_NULL, error_check)
     end
-
+    
+    if Sys.iswindows()
+        @warn "You are using Gtk on Windows which is currently buggy. Expect your REPL/IDE and anything depending on task switches become sluggish."
+    end
     # if g_main_depth > 0, a glib main-loop is already running,
     # so we don't need to start a new one
     if ccall((:g_main_depth, GLib.libglib), Cint, ()) == 0


### PR DESCRIPTION
After the second time wasting quite a bit of time to debug why everything is suddenly sluggish, until I noticed that some unexpected third party library was loading in Gtk, I come to the conclusion that we really need this warning.