### PR TITLE
Support signal_handler_is_connected

### DIFF
--- a/src/GLib/signals.jl
+++ b/src/GLib/signals.jl
@@ -124,6 +124,15 @@ signal_handler_block(w::GObject, handler_id::Culong) =
 signal_handler_unblock(w::GObject, handler_id::Culong) =
     ccall((:g_signal_handler_unblock, libgobject), Nothing, (Ptr{GObject}, Culong), w, handler_id)
 
+"""
+    tf = signal_handler_is_connected(widget, id)
+
+Return `true`/`false` depending on whether `widget` has a connected signal handler with
+the given `id`.
+"""
+signal_handler_is_connected(w::GObject, handler_id::Culong) =
+    ccall((:g_signal_handler_is_connected, libgobject), Cint, (Ptr{GObject}, Culong), w, handler_id) == 1
+
 function signal_emit(w::GObject, sig::AbstractStringLike, RT::Type, args...)
     i = isa(sig, AbstractString) ? something(findfirst("::", sig), 0:-1) : (0:-1)
     if !isempty(i)

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -15,7 +15,7 @@ using .GLib.MutableTypes
 import .GLib: set_gtk_property!, get_gtk_property, getproperty, FieldRef
 import .GLib:
     signal_connect, signal_handler_disconnect,
-    signal_handler_block, signal_handler_unblock,
+    signal_handler_block, signal_handler_unblock, signal_handler_is_connected,
     signal_emit, unsafe_convert,
     AbstractStringLike, bytestring
 
@@ -85,7 +85,7 @@ function __init__()
     loaders_cache_name = "gdk-pixbuf-loaders-cache"
     loaders_cache_hash = artifact_hash(loaders_cache_name, mutable_artifacts_toml)
     if loaders_cache_hash === nothing
-        # Run gdk-pixbuf-query-loaders, capture output, 
+        # Run gdk-pixbuf-query-loaders, capture output,
         loader_cache_contents = gdk_pixbuf_query_loaders() do gpql
             withenv("GDK_PIXBUF_MODULEDIR" => gdk_pixbuf_loaders_dir) do
                 return String(read(`$gpql`))
@@ -149,7 +149,7 @@ module ShortNames
     using ..Gtk
     import ..GLib:
         signal_connect, signal_handler_disconnect,
-        signal_handler_block, signal_handler_unblock,
+        signal_handler_block, signal_handler_unblock, signal_handler_is_connected,
         signal_emit
     import ..GLib.@g_type_delegate
     import ..Gtk: suffix

--- a/src/basic_exports.jl
+++ b/src/basic_exports.jl
@@ -21,7 +21,7 @@ export response
 
 # GLib-imported event handling
 export signal_connect, signal_handler_disconnect,
-    signal_handler_block, signal_handler_unblock,
+    signal_handler_block, signal_handler_unblock, signal_handler_is_connected,
     signal_emit, g_timeout_add, g_idle_add
 
 # Gtk-specific event handling

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -54,7 +54,7 @@ wdth, hght = screen_size()
 if !Sys.iswindows()
     @test wdth > 0 && hght > 0
 end
-    
+
 @testset "Window" begin
 w = Window("Window", 400, 300) |> showall
 if !Sys.iswindows()
@@ -265,6 +265,7 @@ counter = 0
 id = signal_connect(b, "clicked") do widget
     counter::Int += 1
 end
+@test signal_handler_is_connected(b, id)
 # For testing callbacks
 click(b::Button) = ccall((:gtk_button_clicked,Gtk.libgtk),Nothing,(Ptr{Gtk.GObject},),b)
 


### PR DESCRIPTION
This can be useful for preventing Gtk error messages specifying that a widget lacks the given handler. [This Reactive.jl callback](https://github.com/JuliaGizmos/GtkReactive.jl/blob/f8b985bdfdb80da3cb46002f6e36c553eb1e9e58/src/widgets.jl#L51-L57) sometimes tries to fire after the widget has been cleaned up.