### PR TITLE
Support Graphics 1.0 and test set_coordinates (+Documenter bounds)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,6 @@ gdk_pixbuf_jll = "da03df04-f53b-5353-a52f-6a8b0620ced0"
 hicolor_icon_theme_jll = "059c91fe-1bad-52ad-bddd-f7b78713c282"
 
 [compat]
-julia = "1.3"
 Cairo = "1.0.0"
 Cairo_jll = "1.16.0"
 GTK3_jll = "3.24.11"
@@ -29,6 +28,7 @@ Reexport = "0.2"
 adwaita_icon_theme_jll = "3.33.92"
 gdk_pixbuf_jll = "2.38.2"
 hicolor_icon_theme_jll = "0.17.0"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ Cairo = "1.0.0"
 Cairo_jll = "1.16.0"
 GTK3_jll = "3.24.11"
 Glib_jll = "2.59.0"
-Graphics = "0.4.0"
+Graphics = "0.4, 1"
 Reexport = "0.2"
 adwaita_icon_theme_jll = "3.33.92"
 gdk_pixbuf_jll = "2.38.2"
@@ -35,5 +35,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "v0.24"

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -54,7 +54,7 @@ wdth, hght = screen_size()
 if !Sys.iswindows()
     @test wdth > 0 && hght > 0
 end
-    
+
 @testset "Window" begin
 w = Window("Window", 400, 300) |> showall
 if !Sys.iswindows()
@@ -530,6 +530,24 @@ c.draw = function(_)
 end
 draw(c)
 destroy(w)
+end
+
+@testset "SetCoordinates" begin
+    win = Window() |> (cnvs = Canvas(300, 280))
+    draw(cnvs) do c
+        set_coordinates(getgc(c), BoundingBox(0, 1, 0, 1))
+    end
+    Gtk.showall(win)
+    sleep(0.5)
+    mtrx = Gtk.Cairo.get_matrix(getgc(cnvs))
+    if get(ENV, "CI", nothing) === nothing || !Sys.islinux()
+        @test mtrx.xx == 300
+        @test mtrx.yy == 280
+    else
+        @test_broken mtrx.xx == 300
+        @test_broken mtrx.yy == 280
+    end
+    @test mtrx.xy == mtrx.yx == mtrx.x0 == mtrx.y0 == 0
 end
 
 @testset "Menus" begin


### PR DESCRIPTION
In preparation for https://github.com/JuliaGraphics/Graphics.jl/pull/16. It's better if the `set_coordinates` test gets done here since this the top of the dependency hierarchy. I have a suspicion it will fail based on https://github.com/JuliaGizmos/GtkReactive.jl/pull/91 (and that this is a regression), but we will see.