### PR TITLE
Warn on windows

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -70,6 +70,9 @@ include("gio.jl")
 include("application.jl")
 
 function __init__()
+    if Sys.iswindows()
+        @warn "You are using Gtk on Windows which is currently buggy. Expect your REPL/IDE and anything depending on task switches become sluggish."
+    end
     # Set XDG_DATA_DIRS so that Gtk can find its icons and schemas
     ENV["XDG_DATA_DIRS"] = join(filter(x -> x != nothing, [
         dirname(adwaita_icons_dir),

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -71,7 +71,7 @@ include("application.jl")
 
 function __init__()
     if Sys.iswindows()
-        @warn "You are using Gtk on Windows which is currently buggy. Expect your REPL/IDE and anything depending on task switches become sluggish."
+        @warn "You are using Gtk on Windows which is currently not recommended. Your REPL/IDE and anything depending on task switches will become sluggish and much slower (up to ~85x slower)."
     end
     # Set XDG_DATA_DIRS so that Gtk can find its icons and schemas
     ENV["XDG_DATA_DIRS"] = join(filter(x -> x != nothing, [


### PR DESCRIPTION
Can we please, please leave this warning? Debugging this problem can waste days of frustrating debugging, even for experienced Julia developers, as you can see here: https://discourse.julialang.org/t/serious-issue-julia-language-keyboard-lag-typing-very-slow/32081/23
A package, which turns calculating a simple spectrogram from 0.02s to 1.7s (it's actually not as bad anymore, it was 50s before 1.1.0) just by using it anywhere in the dependency stack definitely needs to be warned about.

```Julia
(v1.3) pkg> st Gtk
    Status `C:\Users\sdani\.julia\environments\v1.3\Project.toml`
  [4c0ca9eb] Gtk v1.1.0
julia> versioninfo()
Julia Version 1.3.0
Commit 46ce4d7933 (2019-11-26 06:09 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.1 (ORCJIT, skylake)
Environment:
  JULIA_NUM_THREADS = 8

julia> using DSP
julia> @time stft(rand(300_000));
  0.022403 seconds (13.61 k allocations: 8.404 MiB)
julia> using Gtk
julia> @time stft(rand(300_000));
  1.736896 seconds (533.13 k allocations: 33.170 MiB)
```