### PR TITLE
Allow specifying current folder and suggesting filenames in file dialogs

### DIFF
--- a/docs/src/manual/filedialogs.md
+++ b/docs/src/manual/filedialogs.md
@@ -33,9 +33,14 @@ if isdir(dir)
 end
 ```
 
+The open and save dialogs (incl. native versions) support the keyword argument `current_folder`
+to set the current folder shown when the dialog opens. Both save dialog variants support an additional
+keyword argument, `current_name`, to allow suggesting a filename for saving.
+
 Here are some examples:
 ```julia
 open_dialog("Pick a file")
+open_dialog("Pick a file"; current_folder=homedir())
 open_dialog("Pick some files", select_multiple=true)
 open_dialog("Pick a file", Null(), ("*.jl",))
 open_dialog("Pick some text files", GtkNullContainer(), ("*.txt, *.csv",), select_multiple=true)
@@ -44,6 +49,8 @@ open_dialog("Pick an image file", GtkNullContainer(), ("*.png", "*.jpg", GtkFile
 open_dialog("Pick an image file", GtkNullContainer(), (GtkFileFilter(name="Supported image formats"),))
 
 save_dialog("Save as...", Null(), (GtkFileFilter("*.png, *.jpg", name="All supported formats"), "*.png", "*.jpg"))
+save_dialog("Save as...", Null(), (GtkFileFilter("*.png, *.jpg", name="All supported formats"), "*.png", "*.jpg");
+            current_name="Profile.jpg")
 ```
 
 

--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -87,13 +87,17 @@ function makefilters!(dlgp::GtkFileChooser, filters::Union{AbstractVector, Tuple
     end
 end
 
-function open_dialog(title::AbstractString, parent = GtkNullContainer(), filters::Union{AbstractVector, Tuple} = String[]; kwargs...)
+function open_dialog(title::AbstractString, parent = GtkNullContainer(), filters::Union{AbstractVector, Tuple} = String[];
+                     current_folder::Union{AbstractString, Nothing} = nothing, kwargs...)
     dlg = GtkFileChooserDialog(title, parent, GConstants.GtkFileChooserAction.OPEN,
                                 (("_Cancel", GConstants.GtkResponseType.CANCEL),
                                  ("_Open",   GConstants.GtkResponseType.ACCEPT)); kwargs...)
     dlgp = GtkFileChooser(dlg)
     if !isempty(filters)
         makefilters!(dlgp, filters)
+    end
+    if !isnothing(current_folder)
+        ccall((:gtk_file_chooser_set_current_folder, libgtk), Nothing, (Ptr{GObject}, Ptr{UInt8}), dlgp, current_folder)
     end
     response = run(dlg)
     multiple = get_gtk_property(dlg, :select_multiple, Bool)
@@ -116,11 +120,15 @@ function open_dialog(title::AbstractString, parent = GtkNullContainer(), filters
     return selection
 end
 
-function open_dialog_native(title::AbstractString, parent = GtkNullContainer(), filters::Union{AbstractVector, Tuple} = String[]; kwargs...)
+function open_dialog_native(title::AbstractString, parent = GtkNullContainer(), filters::Union{AbstractVector, Tuple} = String[];
+                            current_folder::Union{AbstractString, Nothing} = nothing, kwargs...)
     dlg = GtkFileChooserNative(title, parent, GConstants.GtkFileChooserAction.OPEN,"_Open","_Cancel"; kwargs...)
     dlgp = GtkFileChooser(dlg)
     if !isempty(filters)
         makefilters!(dlgp, filters)
+    end
+    if !isnothing(current_folder)
+        ccall((:gtk_file_chooser_set_current_folder, libgtk), Nothing, (Ptr{GObject}, Ptr{UInt8}), dlgp, current_folder)
     end
     response = run(dlg)
     multiple = get_gtk_property(dlg, :select_multiple, Bool)
@@ -143,13 +151,21 @@ function open_dialog_native(title::AbstractString, parent = GtkNullContainer(), 
     return selection
 end
 
-function save_dialog(title::AbstractString, parent = GtkNullContainer(), filters::Union{AbstractVector, Tuple} = String[]; kwargs...)
+function save_dialog(title::AbstractString, parent = GtkNullContainer(), filters::Union{AbstractVector, Tuple} = String[];
+                     current_folder::Union{AbstractString, Nothing} = nothing,
+                     current_name::Union{AbstractString, Nothing} = nothing, kwargs...)
     dlg = GtkFileChooserDialog(title, parent, GConstants.GtkFileChooserAction.SAVE,
                                 (("_Cancel", GConstants.GtkResponseType.CANCEL),
                                  ("_Save",   GConstants.GtkResponseType.ACCEPT)); kwargs...)
     dlgp = GtkFileChooser(dlg)
     if !isempty(filters)
         makefilters!(dlgp, filters)
+    end
+    if !isnothing(current_folder)
+        ccall((:gtk_file_chooser_set_current_folder, libgtk), Nothing, (Ptr{GObject}, Ptr{UInt8}), dlgp, current_folder)
+    end
+    if !isnothing(current_name)
+        ccall((:gtk_file_chooser_set_current_name, libgtk), Nothing, (Ptr{GObject}, Ptr{UInt8}), dlgp, current_name)
     end
     ccall((:gtk_file_chooser_set_do_overwrite_confirmation, libgtk), Nothing, (Ptr{GObject}, Cint), dlg, true)
     response = run(dlg)
@@ -162,11 +178,19 @@ function save_dialog(title::AbstractString, parent = GtkNullContainer(), filters
     return selection
 end
 
-function save_dialog_native(title::AbstractString, parent = GtkNullContainer(), filters::Union{AbstractVector, Tuple} = String[]; kwargs...)
+function save_dialog_native(title::AbstractString, parent = GtkNullContainer(), filters::Union{AbstractVector, Tuple} = String[];
+                            current_folder::Union{AbstractString, Nothing} = nothing,
+                            current_name::Union{AbstractString, Nothing} = nothing, kwargs...)
     dlg = GtkFileChooserNative(title, parent, GConstants.GtkFileChooserAction.SAVE,"_Save","_Cancel"; kwargs...)
     dlgp = GtkFileChooser(dlg)
     if !isempty(filters)
         makefilters!(dlgp, filters)
+    end
+    if !isnothing(current_folder)
+        ccall((:gtk_file_chooser_set_current_folder, libgtk), Nothing, (Ptr{GObject}, Ptr{UInt8}), dlgp, current_folder)
+    end
+    if !isnothing(current_name)
+        ccall((:gtk_file_chooser_set_current_name, libgtk), Nothing, (Ptr{GObject}, Ptr{UInt8}), dlgp, current_name)
     end
     ccall((:gtk_file_chooser_set_do_overwrite_confirmation, libgtk), Nothing, (Ptr{GObject}, Cint), dlg, true)
     response = run(dlg)


### PR DESCRIPTION
- `open_dialog` only supports `current_folder`
  - Suggesting a filename to open seems unlikely to be needed or helpful, but we could still
  support setting `current_name` if that seems like a more thorough support of these features.
- `save_dialog` supports both new kwargs

Gtk documentation [recommends against](https://developer.gnome.org/gtk3/stable/GtkFileChooserDialog.html#gtkfilechooserdialog-setting-up)
setting the current folder due to some heuristics in `GtkFileChooser` which are supposed to set sensible/helpful
folders, in my experience the dialogs only ever opened to the "Recent" folder.

I tested that all of the combinations of function & kwargs works properly; it doesn't seem like there is any
other way to test these features via code?

I also added examples to the documentation.

Refs: 
https://developer.gnome.org/gtk3/stable/GtkFileChooser.html#gtk-file-chooser-set-current-name 
https://developer.gnome.org/gtk3/stable/GtkFileChooser.html#gtk-file-chooser-set-current-folder