### PR TITLE
Set optlevel to 1

### DIFF
--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -1,5 +1,9 @@
 module GLib
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
+    @eval Base.Experimental.@optlevel 1
+end
+
 # Import `libgobject` and whatnot
 using Glib_jll
 

--- a/src/GLib/MutableTypes.jl
+++ b/src/GLib/MutableTypes.jl
@@ -1,4 +1,9 @@
 module MutableTypes
+
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
+    @eval Base.Experimental.@optlevel 1
+end
+
 export mutable, Mutable, deref
 
 abstract type Mutable{T} end

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -1,6 +1,10 @@
 # julia Gtk interface
 module Gtk
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
+    @eval Base.Experimental.@optlevel 1
+end
+
 # Import binary definitions
 using GTK3_jll, Glib_jll, Xorg_xkeyboard_config_jll, gdk_pixbuf_jll, adwaita_icon_theme_jll, hicolor_icon_theme_jll
 using Pkg.Artifacts
@@ -107,12 +111,12 @@ function __init__()
             force=true
         )
     end
-    
+
     if Sys.iswindows()
       # needed on windows for correct window decorations (issue 355)
       ENV["GTK_CSD"] = 0
     end
-    
+
     # Point gdk to our cached loaders
     ENV["GDK_PIXBUF_MODULE_FILE"] = joinpath(artifact_path(loaders_cache_hash), "loaders.cache")
     ENV["GDK_PIXBUF_MODULEDIR"] = gdk_pixbuf_loaders_dir


### PR DESCRIPTION
This, together with the same change in GtkReactive and ProfileView, shaves about 200ms off the first call to ProfileView.view(). Not bad, but not a game-changer either.

xref https://github.com/JuliaLang/julia/pull/32705#issuecomment-685155916