### PR TITLE
Replacing gtk_css_provider_get_default by gtk_css_provider_new

### DIFF
--- a/src/theme.jl
+++ b/src/theme.jl
@@ -3,7 +3,7 @@ function GtkCssProviderLeaf(; data = nothing, filename = nothing)
     source_count = (data !== nothing) + (filename !== nothing)
     @assert(source_count <= 1,
         "GtkCssProvider must have at most one data or filename argument")
-    provider = GtkCssProviderLeaf(ccall((:gtk_css_provider_get_default, libgtk), Ptr{GObject}, ()))
+    provider = GtkCssProviderLeaf(ccall((:gtk_css_provider_new, libgtk), Ptr{GObject}, ()))
     if data !== nothing
         GError() do error_check
           ccall((:gtk_css_provider_load_from_data, libgtk), Bool,


### PR DESCRIPTION
According to https://github.com/JuliaGraphics/Gtk.jl/issues/526#issuecomment-702083869

I merely replaced the function name here to get things started. I could not properly test this myself because Gtk.jl master is not working for my projects right now. Is this really all there is to it?