### PR TITLE
Add GdkRGBA, ColorChooserDialog, ColorButton

### DIFF
--- a/src/buttons.jl
+++ b/src/buttons.jl
@@ -163,3 +163,7 @@ function GtkVolumeButtonLeaf(value::Real) # 0 <= value <= 1
 end
 
 GtkFontButtonLeaf() = GtkFontButtonLeaf(ccall((:gtk_font_button_new, libgtk), Ptr{GObject}, ()))
+
+GtkColorButtonLeaf() = GtkColorButtonLeaf(ccall((:gtk_color_button_new, libgtk), Ptr{GObject}, ()))
+GtkColorButtonLeaf(color::GdkRGBA) = GtkColorButtonLeaf(ccall((:gtk_color_button_new_with_rgba, libgtk), Ptr{GObject},
+    (Ref{GdkRGBA},), color))

--- a/src/gdk.jl
+++ b/src/gdk.jl
@@ -15,6 +15,16 @@ struct GdkPoint
 end
 # GdkPoint is not a GBoxed type
 
+struct GdkRGBA
+	r::Cdouble
+	g::Cdouble
+	b::Cdouble
+    a::Cdouble
+    GdkRGBA(r, g, b, a) = new(r, g, b, a)
+end
+@make_gvalue(GdkRGBA, Ptr{GdkRGBA}, :boxed, (:gdk_rgba,:libgdk))
+convert(::Type{GdkRGBA}, rgba::Ptr{GdkRGBA}) = unsafe_load(rgba)
+
 baremodule GdkKeySyms
     const VoidSymbol = 0xffffff
     const BackSpace = 0xff08

--- a/src/gtktypes.jl
+++ b/src/gtktypes.jl
@@ -110,6 +110,8 @@ end
 @gtktype GtkScrolledWindow
 @gtktype GtkAboutDialog
 @gtktype GtkMessageDialog
+@gtktype GtkColorChooserDialog
+@gtktype GtkColorButton
 @Gtype GApplication libgio g_application
 @Gtype GdkPixbuf libgdkpixbuf gdk_pixbuf
 #TODO: @gtktype GtkScaleButton

--- a/src/long_exports.jl
+++ b/src/long_exports.jl
@@ -76,7 +76,9 @@ export GObject,
     GtkToggleToolButton,
     GtkTreeIter,
     GtkWindow,
-    GtkEventBox
+    GtkEventBox,
+    GtkColorChooserDialog,
+    GtkColorButton
 
 # Gtk interfaces
 export GTypePlugin,

--- a/src/long_leaf_exports.jl
+++ b/src/long_leaf_exports.jl
@@ -74,7 +74,9 @@ export
     @GtkTextBuffer,
     @GtkToggleButton,
     @GtkToggleToolButton,
-    @GtkWindow
+    @GtkWindow,
+    @GtkColorChooserDialog,
+    @GtkColorButton
 
 # Gtk objects
 export
@@ -152,7 +154,9 @@ export
     GtkToggleButtonLeaf,
     GtkToggleToolButtonLeaf,
     GtkWindowLeaf,
-    GtkEventBoxLeaf
+    GtkEventBoxLeaf,
+    GtkColorChooserDialogLeaf,
+    GtkColorButtonLeaf
 
 
 # Gtk3 objects

--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -178,3 +178,21 @@ function save_dialog_native(title::AbstractString, parent = GtkNullContainer(), 
     GLib.gc_unref(dlg) #destroy(dlg)
     return selection
 end
+
+function GtkColorChooserDialogLeaf(title::AbstractString, parent::GtkContainer; kwargs...)
+    return GtkColorChooserDialogLeaf(ccall((:gtk_color_chooser_dialog_new, libgtk), Ptr{GObject},
+            (Ptr{UInt8}, Ptr{GObject}),
+            title, parent); kwargs...)
+end
+
+function color_chooser_dialog(title::AbstractString, parent = GtkNullContainer(); kwargs...)
+    dlg = GtkColorChooserDialog(title, parent; kwargs...)
+    response = run(dlg)
+    if response == GConstants.GtkResponseType.OK
+        selection = GAccessor.rgba(dlg)
+    else
+        selection = nothing
+    end
+    destroy(dlg)
+    return selection
+end

--- a/src/short_exports.jl
+++ b/src/short_exports.jl
@@ -78,6 +78,8 @@ const TreeViewColumn = GtkTreeViewColumn
 const VolumeButton = GtkVolumeButton
 const Window = GtkWindow
 const EventBox = GtkEventBox
+const ColorChooserDialog = GtkColorChooserDialog,
+const ColorButton = GtkColorButton
 
 export G_, GObject,
     AboutDialog,
@@ -156,7 +158,9 @@ export G_, GObject,
     TreeViewColumn,
     VolumeButton,
     Window,
-    EventBox
+    EventBox,
+    ColorChooserDialog,
+    ColorButton
 
 const TypePlugin = GTypePlugin
 const Buildable = GtkBuildable

--- a/src/short_exports.jl
+++ b/src/short_exports.jl
@@ -78,7 +78,7 @@ const TreeViewColumn = GtkTreeViewColumn
 const VolumeButton = GtkVolumeButton
 const Window = GtkWindow
 const EventBox = GtkEventBox
-const ColorChooserDialog = GtkColorChooserDialog,
+const ColorChooserDialog = GtkColorChooserDialog
 const ColorButton = GtkColorButton
 
 export G_, GObject,

--- a/src/short_leaf_exports.jl
+++ b/src/short_leaf_exports.jl
@@ -74,6 +74,8 @@
 @g_type_delegate TreeViewColumn = GtkTreeViewColumn
 @g_type_delegate VolumeButton = GtkVolumeButton
 @g_type_delegate Window = GtkWindow
+@g_type_delegate ColorChooserDialog = GtkColorChooserDialog
+@g_type_delegate ColorButton = GtkColorButton
 
 export @G_,
     @AboutDialog,
@@ -149,7 +151,9 @@ export @G_,
     @TreeView,
     @TreeViewColumn,
     @VolumeButton,
-    @Window
+    @Window,
+    @ColorChooserDialog,
+    @ColorButton
 
 export G_Leaf,
     AboutDialogLeaf,
@@ -222,7 +226,9 @@ export G_Leaf,
     TreeViewLeaf,
     TreeViewColumnLeaf,
     VolumeButtonLeaf,
-    WindowLeaf
+    WindowLeaf,
+    ColorChooserDialog,
+    ColorButton
 
 # Gtk 3
 @g_type_delegate Grid = GtkGrid

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -416,6 +416,13 @@ w = Window(b, "VolumeButton", 50, 50)|>showall
 destroy(w)
 end
 
+@testset "ColorButton" begin
+b = ColorButton(Gtk.GdkRGBA(0, 0.8, 1.0, 0.3))
+w = Window(b, "ColorButton", 50, 50)|>showall
+GAccessor.rgba(ColorChooser(b), GLib.mutable(Gtk.GdkRGBA(0, 0, 0, 0)))
+destroy(w)
+end
+
 @testset "combobox" begin
 combo = ComboBoxText()
 choices = ["Strawberry", "Vanilla", "Chocolate"]
@@ -615,11 +622,16 @@ end
 #@test get_value(tr)[1] == choices[2]
 #destroy(w)
 
-@testset "Selectors" begin
+@testset "File Chooser" begin
     dlg = FileChooserDialog("Select file", Null(), GtkFileChooserAction.OPEN,
                             (("_Cancel", GtkResponseType.CANCEL),
                              ("_Open", GtkResponseType.ACCEPT)))
     destroy(dlg)
+end
+
+@testset "Color Chooser" begin
+dlg = ColorChooserDialog("Select color", Null())
+destroy(dlg)
 end
 
 @testset "List view" begin


### PR DESCRIPTION
Relevant Gtk docs: [GdkRGBA](https://developer.gnome.org/gdk3/stable/gdk3-RGBA-Colors.html), [GtkColorChooserDialog](https://developer.gnome.org/gtk3/stable/GtkColorChooserDialog.html), [GtkColorButton](https://developer.gnome.org/gtk3/stable/GtkColorButton.html).

Partially replaces #244 (and by extension partially closes #243).

Also adds `color_chooser_dialog` convenience function for displaying a GtkColorChooserDialog similarly to `open_dialog`/`save_dialog`.
`color_chooser_dialog`  returns `nothing` if no color is selected (cancel or close button pressed) to distinguish from just selecting the default color.

GtkColorChooserDialog is still subject to #530, so it may be worth also adding the deprecated GtkColorSelectionDialog, which seems to work just fine.

I also took a look at the generator scripts; the Clang ones are outdated for the latest version of Clang.jl, and I was unable to successfully downgrade the package to test their recommendation for [Backwards Compatibility](https://github.com/JuliaInterop/Clang.jl#backward-compatibility).