### PR TITLE
Add delete and insert for TreeView

### DIFF
--- a/src/lists.jl
+++ b/src/lists.jl
@@ -699,6 +699,17 @@ function push!(treeView::GtkTreeView, treeColumns::GtkTreeViewColumn...)
     end
     treeView
 end
+function insert!(treeView::GtkTreeView, index::Integer, treeColumn::GtkTreeViewColumn)
+    ccall((:gtk_tree_view_insert_column, libgtk), Nothing, (Ptr{GObject}, Ptr{GObject}, Cint), treeView, treeColumn, index - 1)
+    treeView
+end
+function delete!(treeView::GtkTreeView, treeColumns::GtkTreeViewColumn...)
+    for col in treeColumns
+        ccall((:gtk_tree_view_remove_column, libgtk), Nothing, (Ptr{GObject}, Ptr{GObject}), treeView, col)
+    end
+    treeView
+end
+
 
 # TODO Use internal accessor with default values?
 function path_at_pos(treeView::GtkTreeView, x::Integer, y::Integer)

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -634,6 +634,8 @@ c1=TreeViewColumn("A", r1, Dict([("text",0)]))
 c2=TreeViewColumn("B", r2, Dict([("active",1)]))
 push!(tv,c1)
 push!(tv,c2)
+delete!(tv, c1)
+insert!(tv, 1, c1)
 w = Window(tv, "List View")|>showall
 
 ## selection


### PR DESCRIPTION
Closes #514 
Adds `delete!` and `insert!` for manipulating TreeViewColumns in a TreeView.

I went with `delete!` over the requested `deleteat!` since the user is providing the object(s) to be removed, rather than the index of the object to be removed.
I did however note that [ListStore](https://github.com/JuliaGraphics/Gtk.jl/blob/master/src/lists.jl#L168) does provide both names, should that be done here too?
