### PR TITLE
Use DOCUMENTER_KEY for CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -12,3 +12,4 @@ jobs:
         run: julia -e 'using CompatHelper; CompatHelper.main()'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This allows CI to run in pull requests opened by CompatHelper.

Ref https://github.com/JuliaGraphics/Gtk.jl/pull/544#issuecomment-751408042.  CC: @timholy.