### PR TITLE
Slightly expand precompiles

### DIFF
--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -78,4 +78,9 @@ macro g_type_delegate(eq)
     end
 end
 
+if Base.VERSION >= v"1.4.2"
+    precompile(Tuple{typeof(addref),Any})   # time: 0.003988418
+    precompile(Tuple{typeof(gc_ref),Any})   # time: 0.002649791
+end
+
 end

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -75,11 +75,11 @@ include("application.jl")
 
 function __init__()
     # Set XDG_DATA_DIRS so that Gtk can find its icons and schemas
-    ENV["XDG_DATA_DIRS"] = join(filter(x -> x != nothing, [
+    ENV["XDG_DATA_DIRS"] = join(filter(x -> x !== nothing, [
         dirname(adwaita_icons_dir),
         dirname(hicolor_icons_dir),
-        joinpath(dirname(GTK3_jll.libgdk3_path), "..", "share"),
-        get(ENV, "XDG_DATA_DIRS", nothing),
+        joinpath(dirname(GTK3_jll.libgdk3_path::String), "..", "share"),
+        get(ENV, "XDG_DATA_DIRS", nothing)::Union{String,Nothing},
     ]), Sys.iswindows() ? ";" : ":")
 
     # Next, ensure that gdk-pixbuf has its loaders.cache file; we generate a
@@ -117,7 +117,7 @@ function __init__()
         # Needed by xkbcommon:
         # https://xkbcommon.org/doc/current/group__include-path.html.  Related
         # to issue https://github.com/JuliaGraphics/Gtk.jl/issues/469
-        ENV["XKB_CONFIG_ROOT"] = joinpath(Xorg_xkeyboard_config_jll.artifact_dir,
+        ENV["XKB_CONFIG_ROOT"] = joinpath(Xorg_xkeyboard_config_jll.artifact_dir::String,
                                           "share", "X11", "xkb")
     end
 
@@ -156,8 +156,10 @@ using .GConstants
 include("windows.jl")
 include("gl_area.jl")
 
-include("precompile.jl")
-_precompile_()
+if Base.VERSION >= v"1.4.2"
+    include("precompile.jl")
+    _precompile_()
+end
 
 # Alternative Interface (`using Gtk.ShortNames`)
 module ShortNames

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -16,4 +16,9 @@ function _precompile_()
     precompile(Tuple{typeof(signal_connect),Function,GtkComboBoxTextLeaf,Symbol})
     precompile(Tuple{typeof(setindex!),Dict{Union{WeakRef, GObject},Bool},Bool,GtkTextBufferLeaf})
     precompile(Tuple{typeof(notify_realize),Ptr{GObject},GtkCanvas})
+    precompile(Tuple{typeof(mouseup_cb),Ptr{GObject},Ptr{GdkEventButton},MouseHandler})   # time: 0.026400313
+    precompile(Tuple{typeof(toplevel),GtkCanvas})   # time: 0.023317223
+    precompile(Tuple{typeof(notify_motion),Ptr{GObject},Ptr{GdkEventMotion},Gtk_signal_motion{MouseHandler}})   # time: 0.001248276
+    precompile(Tuple{typeof(canvas_on_draw_event),Ptr{GObject},Ptr{Nothing},GtkCanvas})   # time: 0.001126875
+    precompile(Tuple{typeof(mousedown_cb),Ptr{GObject},Ptr{GdkEventButton},MouseHandler})   # time: 0.001090291
 end


### PR DESCRIPTION
These were found via the new capabilities in the soon-to-be-released SnoopCompile. Not a big change but you can see the time savings in the comment after each line.