### PR TITLE
Add environment for generator scripts

### DIFF
--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+GTK3_jll = "77ec8976-b24b-556a-a1bf-49a033a670a6"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"


### PR DESCRIPTION
Minimal Project file for the generator scripts. See https://github.com/JuliaGraphics/Gtk.jl/pull/535#issuecomment-760067299.

From CI or tests, it'd be called like this:

```julia
using Gtk # latest Gtk from dev, imported in the main or test Gtk env
using Pkg
Pkg.activate("$root/gen")
Pkg.instantiate()
include("gtk_auto_gen.jl")
```
The generator scripts depend on the dev version of Gtk.jl, but actually making the environment depend on it isn't possible without including the `Manifest.toml` (using `repo-url = ".."`), which probably shouldn't be done.