### PR TITLE
showall(win) is needed after push!() hbox, cancel, and ok

### DIFF
--- a/docs/src/manual/layout.md
+++ b/docs/src/manual/layout.md
@@ -48,6 +48,7 @@ hbox = GtkButtonBox(:h)
 push!(win, hbox)
 push!(hbox, cancel)
 push!(hbox, ok)
+showall(win)
 ```
 
 Now we get this:


### PR DESCRIPTION
showall(win) is needed after push!() hbox, cancel, and ok. Otherwise the new GtkButtonBox hbox will not show, nor will the cancel and ok GtkButton's.