### PR TITLE
Avoid full CI on changes to docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: "master"
     tags: ["*"]
   pull_request:
+    paths-ignore:
+      - '**.md'
   release:
 
 jobs:


### PR DESCRIPTION
I noticed that #597 was doing a full CI run even though it is just a change to a `.md` file.
This (untested) PR hopefully should reduce the carbon footprint of future PRs that are just documentation updates.
It's quite possible that it needs tweaking to be correct.