### PR TITLE
fix a test of List view

### DIFF
--- a/src/lists.jl
+++ b/src/lists.jl
@@ -183,7 +183,7 @@ end
 
 deleteat!(listStore::GtkListStoreLeaf, index::Int) = delete!(listStore, iter_from_index(listStore, index))
 pop!(listStore::GtkListStoreLeaf) = deleteat!(listStore, length(listStore))
-popfirst!(listSTore::GtkListStoreLeaf) = deleteat!(listStore, 1)
+popfirst!(listStore::GtkListStoreLeaf) = deleteat!(listStore, 1)
 
 
 isvalid(listStore::GtkListStore, iter::TRI) =

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -655,7 +655,9 @@ iter = selected(selmodel)
 @test Gtk.index_from_iter(ls, iter) == 1
 @test ls[iter, 1] == 44
 deleteat!(ls, iter)
-@test isvalid(ls, iter) == false
+select!(selmodel, Gtk.iter_from_index(ls, 1))
+iter = selected(selmodel)
+@test ls[iter, 1] == 35
 
 tmSorted=TreeModelSort(ls)
 G_.model(tv,tmSorted)


### PR DESCRIPTION
Fixes an invalid read in a test found using valgrind. The test assumes that the iter is invalidated by deleteat!(), but according to the GTK docs that should only happen if the iter points to the last row (which it doesn't). Plus the iter is passed in as an immutable struct, so it doesn't seem like it could change. Anyway, the gtk_list_store_iter_is_valid() call attempts to access the row that was just deleted. I added a test that verifies the row was deleted. Also fixes a typo in the ListStore code.