### PR TITLE
Preserve GValues from GC (fixes #581)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Gtk"
 uuid = "4c0ca9eb-093a-5379-98c5-f87ac0bbbf44"
-version = "1.1.9"
+version = "1.1.10"
 
 [deps]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"

--- a/src/GLib/signals.jl
+++ b/src/GLib/signals.jl
@@ -142,7 +142,8 @@ function signal_emit(w::GObject, sig::AbstractStringLike, ::Type{RT}, args...) w
     end
     signal_id = ccall((:g_signal_lookup, libgobject), Cuint, (Ptr{UInt8}, Csize_t), sig, G_OBJECT_CLASS_TYPE(w))
     return_value = RT === Nothing ? C_NULL : gvalue(RT)
-    ccall((:g_signal_emitv, libgobject), Nothing, (Ptr{GValue}, Cuint, UInt32, Ptr{GValue}), gvalues(w, args...), signal_id, detail, return_value)
+    gvals = gvalues(w, args...)
+    GC.@preserve gvals return_value ccall((:g_signal_emitv, libgobject), Nothing, (Ptr{GValue}, Cuint, UInt32, Ptr{GValue}), gvals, signal_id, detail, return_value)
     RT === Nothing ? nothing : return_value[RT]
 end
 


### PR DESCRIPTION
As a consequence of the forced specialization on the `RT` argument
of `signal_emit` in #552, the compiler now knows whether
`RT === Nothing`. In that case, it also knows that
`return_value` will not be used, so it is free to be garbage-collected.
When that happens, it triggers segfaults. EDIT: actually, that can't
be correct, because it doesn't create them when `RT===Nothing`.
So probably #552 didn't trigger this.

This puts both potential `GValue`-arguments inside a `GC.@preserve`
to prevent garbage collection. Fixes #581.

A reproducer of the crash is with GtkObservables:
```sh
/some/path/GtkObservables$ julia --check-bounds=yes --color=yes --depwarn=yes --inline=yes --project=@. -e 'import Pkg; Pkg.test(; coverage=true)'
```
but that is obviously difficult to convert into a test. I've run it 5 times locally and have yet to see a crash, which did not happen before this commit.