### PR TITLE
add tests for GList, fix a few things related to GList

### DIFF
--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -16,7 +16,7 @@ end
 
 import Base: convert, copy, show, size, length, getindex, setindex!, get,
              iterate, eltype, isempty, ndims, stride, strides, popfirst!,
-             empty!, append!, reverse!, pushfirst!, pop!, push!, splice!,
+             empty!, append!, reverse!, pushfirst!, pop!, push!, splice!, insert!,
              sigatomic_begin, sigatomic_end, Sys.WORD_SIZE, unsafe_convert, getproperty,
              getindex, setindex!
 
@@ -24,7 +24,7 @@ using Libdl
 
 export GInterface, GType, GObject, GBoxed, @Gtype, @Gabstract, @Giface
 export GEnum, GError, GValue, gvalue, make_gvalue, @make_gvalue, g_type
-export GList, glist_iter, _GSList, _GList, gobject_ref, gobject_move_ref
+export GList, GSList, glist_iter, _GSList, _GList, gobject_ref, gobject_move_ref
 export signal_connect, signal_emit, signal_handler_disconnect
 export signal_handler_block, signal_handler_unblock
 export g_timeout_add, g_idle_add, @idle_add

--- a/test/glist.jl
+++ b/test/glist.jl
@@ -42,7 +42,6 @@ end
 @test g[2]==string(2)
 
 @test length(g)==10
-@test g[begin]==string(1)
 @test g[end]==string(10)
 
 for (i,item) = enumerate(g)
@@ -95,7 +94,6 @@ end
 @test g[2]==string(2)
 
 @test length(g)==10
-@test g[begin]==string(1)
 @test g[end]==string(10)
 
 for (i,item) = enumerate(g)
@@ -151,7 +149,6 @@ end
 @test g[2]==2
 
 @test length(g)==10
-@test g[begin]==1
 @test g[end]==10
 
 for (i,item) = enumerate(g)
@@ -184,7 +181,6 @@ end
 @test g[2]==2
 
 @test length(g)==10
-@test g[begin]==1
 @test g[end]==10
 
 for (i,item) = enumerate(g)

--- a/test/glist.jl
+++ b/test/glist.jl
@@ -1,0 +1,205 @@
+using Gtk.GLib
+using Gtk
+using Gtk.ShortNames
+using Test
+
+@testset "glist" begin
+
+@testset "pointers" begin
+
+w = Window("Window", 400, 300)
+nb = Notebook()
+w = push!(Window("Notebook"),nb)
+l = ccall((:gtk_container_get_children,Gtk.libgtk),Ptr{Gtk._GList{Gtk.GtkWidget}},(Ptr{Gtk.GObject},),w)
+
+@test eltype(l)==Gtk.GtkWidget
+
+@test !isempty(l)
+@test length(l)==1
+@test l[1]==nb
+
+for item in l
+    @test item==nb
+end
+
+end
+
+@testset "string" begin
+
+g = GList(String)
+
+@test ndims(g)==1
+
+@test isempty(g)
+
+for i=1:10
+    push!(g,string(i))
+end
+
+@test !isempty(g)
+
+@test g[1]==string(1)
+@test g[2]==string(2)
+
+@test length(g)==10
+@test g[begin]==string(1)
+@test g[end]==string(10)
+
+for (i,item) = enumerate(g)
+    @test string(i)==item
+end
+
+g2=copy(g)
+
+for (i,item) = enumerate(g2)
+    @test string(i)==item
+end
+
+insert!(g,8,string(25))
+@test length(g)==11
+@test g[8]==string(25)
+@test g[9]==string(8)
+
+pushfirst!(g,string(24))
+@test length(g)==12
+@test g[1]==string(24)
+@test g[9]==string(25)
+
+g[8]="hello"
+@test g[8]=="hello"
+@test g[9]==string(25)
+
+reverse!(g)
+@test g[end]==string(24)
+
+g[2]="test"
+@test g[2]=="test"
+
+empty!(g)
+@test isempty(g)
+
+# repeat above for GSList
+g = GSList(String)
+
+@test ndims(g)==1
+
+@test isempty(g)
+
+for i=1:10
+    push!(g,string(i))
+end
+
+@test !isempty(g)
+
+@test g[1]==string(1)
+@test g[2]==string(2)
+
+@test length(g)==10
+@test g[begin]==string(1)
+@test g[end]==string(10)
+
+for (i,item) = enumerate(g)
+    @test string(i)==item
+end
+
+g2=copy(g)
+
+for (i,item) = enumerate(g2)
+    @test string(i)==item
+end
+
+insert!(g,8,string(25))
+@test length(g)==11
+@test g[8]==string(25)
+@test g[9]==string(8)
+
+pushfirst!(g,string(24))
+@test length(g)==12
+@test g[1]==string(24)
+@test g[9]==string(25)
+
+g[8]="hello"
+@test g[8]=="hello"
+@test g[9]==string(25)
+
+reverse!(g)
+@test g[end]==string(24)
+
+g[2]="test"
+@test g[2]=="test"
+
+empty!(g)
+@test isempty(g)
+
+end
+
+@testset "numbers" begin
+
+g = GList(Int64)
+
+@test ndims(g)==1
+
+@test isempty(g)
+
+for i=1:10
+    push!(g,i)
+end
+
+@test !isempty(g)
+
+@test g[1]==1
+@test g[2]==2
+
+@test length(g)==10
+@test g[begin]==1
+@test g[end]==10
+
+for (i,item) = enumerate(g)
+    @test i==item
+end
+
+g2=copy(g)
+
+for (i,item) = enumerate(g2)
+    @test i==item
+end
+
+empty!(g)
+@test isempty(g)
+
+# repeat above for SList
+g = GSList(Int64)
+
+@test ndims(g)==1
+
+@test isempty(g)
+
+for i=1:10
+    push!(g,i)
+end
+
+@test !isempty(g)
+
+@test g[1]==1
+@test g[2]==2
+
+@test length(g)==10
+@test g[begin]==1
+@test g[end]==10
+
+for (i,item) = enumerate(g)
+    @test i==item
+end
+
+g2=copy(g)
+
+for (i,item) = enumerate(g2)
+    @test i==item
+end
+
+empty!(g)
+@test isempty(g)
+
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ module GtkTestModule
 using Test, Gtk
 
 include("glib.jl")
+include("glist.jl")
 include("gui.jl")
 include("list.jl")
 include("misc.jl")


### PR DESCRIPTION
Adds tests for GList and fixes a couple of bugs. Also removes some array interface declarations that don't seem to be necessary.

* In the string code, rename unsafe_copy! to unsafe_copyto!.
* Explicitly convert a number to a pointer for storing numbers in a GList.
* Add a constructor for GSList for testing purposes.
* Remove a few standard array interface declarations that don't seem necessary since they are the default.