### PR TITLE
Automatic event loop start/stop when not showing anything

### DIFF
--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -32,6 +32,7 @@ export set_gtk_property!, get_gtk_property
 export GConnectFlags
 export @sigatom, cfunction_
 
+const IDLE = Ref{Bool}(true)
 
 cfunction_(@nospecialize(f), r, a::Tuple) = cfunction_(f, r, Tuple{a...})
 

--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -32,7 +32,6 @@ export set_gtk_property!, get_gtk_property
 export GConnectFlags
 export @sigatom, cfunction_
 
-const IDLE = Ref{Bool}(true)
 
 cfunction_(@nospecialize(f), r, a::Tuple) = cfunction_(f, r, Tuple{a...})
 
@@ -41,6 +40,8 @@ cfunction_(@nospecialize(f), r, a::Tuple) = cfunction_(f, r, Tuple{a...})
         @cfunction($(Expr(:$,:f)), $rt, ($(at.parameters...),))
     end
 end
+
+const gtk_eventloop_f = Ref{Function}()
 
 # local function, handles Symbol and makes UTF8-strings easier
 const  AbstractStringLike = Union{AbstractString, Symbol}

--- a/src/GLib/signals.jl
+++ b/src/GLib/signals.jl
@@ -288,7 +288,9 @@ function uv_prepare(src::Ptr{Nothing}, timeout::Ptr{Cint})
     global expiration, uv_pollfd
     local tmout_ms::Cint
     evt = Base.eventloop()
-    if !_isempty_workqueue()
+    if IDLE[]
+        return Int32(1)
+    elseif !_isempty_workqueue()
         tmout_ms = 0
     elseif !uv_loop_alive(evt)
         tmout_ms = -1
@@ -316,7 +318,7 @@ end
 function uv_check(src::Ptr{Nothing})
     global expiration
     ex = expiration::UInt64
-    if !_isempty_workqueue()
+    if !_isempty_workqueue() || IDLE[]
         return Int32(1)
     elseif !uv_loop_alive(Base.eventloop())
         return Int32(0)

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -135,6 +135,24 @@ function __init__()
     end
 end
 
+"""
+    Gtk.idle(b::Bool = true)
+
+Set whether Gtk's event loop should be idle.
+"""
+function idle(b::Bool)
+    GLib.IDLE[] = b
+end
+
+"""
+    Gtk.isidle()::Bool
+
+Check whether Gtk's event loop is idle.
+"""
+function isidle()
+    GLib.IDLE[]
+end
+
 const ser_version = Serialization.ser_version
 let cachedir = joinpath(splitdir(@__FILE__)[1], "..", "gen")
     fastgtkcache = joinpath(cachedir, "gtk$(libgtk_version.major)_julia_ser$(ser_version)")

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -134,8 +134,11 @@ function __init__()
         global gtk_main_task = schedule(Task(gtk_main))
     end
 
-    idle(get(ENV, "GTK_START_IDLE", "true") == "true")
+    AUTO_IDLE[] = get(ENV, "GTK_AUTO_IDLE", "true") == "true"
+    idle(AUTO_IDLE[])
 end
+
+const AUTO_IDLE = Ref{Bool}(true)
 
 """
     Gtk.idle(b::Bool = true)

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -133,6 +133,8 @@ function __init__()
     if ccall((:g_main_depth, GLib.libglib), Cint, ()) == 0
         global gtk_main_task = schedule(Task(gtk_main))
     end
+
+    idle(get(ENV, "GTK_START_IDLE", "true") == "true")
 end
 
 """

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -128,35 +128,49 @@ function __init__()
             C_NULL, C_NULL, "Julia Gtk Bindings", C_NULL, C_NULL, error_check)
     end
 
-    # if g_main_depth > 0, a glib main-loop is already running,
-    # so we don't need to start a new one
-    if ccall((:g_main_depth, GLib.libglib), Cint, ()) == 0
-        global gtk_main_task = schedule(Task(gtk_main))
+    # if g_main_depth > 0, a glib main-loop is already running.
+    # unfortunately this call does not reliably reflect the state after the
+    # loop has been stopped or restarted, so only use it once at the start
+    gtk_main_running[] = ccall((:g_main_depth, GLib.libglib), Cint, ()) > 0
+
+    # Given GLib provides `g_idle_add` to specify what happens during idle, this allows
+    # that call to also start the eventloop
+    GLib.gtk_eventloop_f[] = enable_eventloop
+
+    auto_idle[] = get(ENV, "GTK_AUTO_IDLE", "true") == "true"
+
+    # by default, defer starting the event loop until either `show`, `showall`, or `g_idle_add` is called
+    enable_eventloop(!auto_idle[])
+end
+
+const auto_idle = Ref{Bool}(true) # control default via ENV["GTK_AUTO_IDLE"]
+const gtk_main_running = Ref{Bool}(false)
+
+"""
+    Gtk.enable_eventloop(b::Bool = true)
+
+Set whether Gtk's event loop is running.
+"""
+function enable_eventloop(b::Bool = true)
+    if b
+        if !is_eventloop_running()
+            global gtk_main_task = schedule(Task(gtk_main))
+            gtk_main_running[] = true
+        end
+    else
+        if is_eventloop_running()
+            gtk_quit()
+            gtk_main_running[] = false
+        end
     end
-
-    AUTO_IDLE[] = get(ENV, "GTK_AUTO_IDLE", "true") == "true"
-    idle(AUTO_IDLE[])
-end
-
-const AUTO_IDLE = Ref{Bool}(true)
-
-"""
-    Gtk.idle(b::Bool = true)
-
-Set whether Gtk's event loop should be idle.
-"""
-function idle(b::Bool)
-    GLib.IDLE[] = b
 end
 
 """
-    Gtk.isidle()::Bool
+    Gtk.is_eventloop_running()::Bool
 
-Check whether Gtk's event loop is idle.
+Check whether Gtk's event loop is running.
 """
-function isidle()
-    GLib.IDLE[]
-end
+is_eventloop_running() = gtk_main_running[]
 
 const ser_version = Serialization.ser_version
 let cachedir = joinpath(splitdir(@__FILE__)[1], "..", "gen")

--- a/src/base.jl
+++ b/src/base.jl
@@ -31,11 +31,13 @@ visible(w::GtkWidget, state::Bool) = @sigatom ccall((:gtk_widget_set_visible, li
 const shown_widgets = WeakKeyDict()
 function handle_auto_idle(w::GtkWidget)
     if auto_idle[]
-        enable_eventloop(true)
-        shown_widgets[w] = nothing
-        signal_connect(w, :destroy) do w
-            delete!(shown_widgets, w)
-            isempty(shown_widgets) && enable_eventloop(false)
+        signal_connect(w, :realize) do w
+            enable_eventloop(true)
+            shown_widgets[w] = nothing
+            signal_connect(w, :destroy) do w
+                delete!(shown_widgets, w)
+                isempty(shown_widgets) && enable_eventloop(false)
+            end
         end
     end
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -27,8 +27,8 @@ screen_size(w::GtkWindowLeaf) = screen_size(Gtk.GAccessor.screen(w))
 ### Functions and methods common to all GtkWidget objects
 visible(w::GtkWidget) = Bool(ccall((:gtk_widget_get_visible, libgtk), Cint, (Ptr{GObject},), w))
 visible(w::GtkWidget, state::Bool) = @sigatom ccall((:gtk_widget_set_visible, libgtk), Nothing, (Ptr{GObject}, Cint), w, state)
-show(w::GtkWidget) = (@sigatom ccall((:gtk_widget_show, libgtk), Nothing, (Ptr{GObject},), w); w)
-showall(w::GtkWidget) = (@sigatom ccall((:gtk_widget_show_all, libgtk), Nothing, (Ptr{GObject},), w); w)
+show(w::GtkWidget) = (idle(false); @sigatom ccall((:gtk_widget_show, libgtk), Nothing, (Ptr{GObject},), w); w)
+showall(w::GtkWidget) = (idle(false); @sigatom ccall((:gtk_widget_show_all, libgtk), Nothing, (Ptr{GObject},), w); w)
 hide(w::GtkWidget) = (@sigatom ccall((:gtk_widget_hide , libgtk),Cvoid,(Ptr{GObject},),w); w)
 grab_focus(w::GtkWidget) = (@sigatom ccall((:gtk_widget_grab_focus , libgtk), Cvoid, (Ptr{GObject},), w); w)
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -28,14 +28,14 @@ screen_size(w::GtkWindowLeaf) = screen_size(Gtk.GAccessor.screen(w))
 visible(w::GtkWidget) = Bool(ccall((:gtk_widget_get_visible, libgtk), Cint, (Ptr{GObject},), w))
 visible(w::GtkWidget, state::Bool) = @sigatom ccall((:gtk_widget_set_visible, libgtk), Nothing, (Ptr{GObject}, Cint), w, state)
 
-const SHOWN_WIDGETS = WeakKeyDict()
+const shown_widgets = WeakKeyDict()
 function handle_auto_idle(w::GtkWidget)
-    if AUTO_IDLE[]
-        idle(false)
-        SHOWN_WIDGETS[w] = nothing
+    if auto_idle[]
+        enable_eventloop(true)
+        shown_widgets[w] = nothing
         signal_connect(w, :destroy) do w
-            delete!(SHOWN_WIDGETS, w)
-            isempty(SHOWN_WIDGETS) && idle(true)
+            delete!(shown_widgets, w)
+            isempty(shown_widgets) && enable_eventloop(false)
         end
     end
 end

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -17,9 +17,9 @@ end
 
 resize!(win::GtkWindow, w::Integer, h::Integer) = ccall((:gtk_window_resize, libgtk), Nothing, (Ptr{GObject}, Int32, Int32), win, w, h)
 
-present(win::GtkWindow) = ccall((:gtk_window_present, libgtk), Nothing, (Ptr{GObject},), win)
+present(win::GtkWindow) = (handle_auto_idle(win); ccall((:gtk_window_present, libgtk), Nothing, (Ptr{GObject},), win))
 
-fullscreen(win::GtkWindow) = ccall((:gtk_window_fullscreen, libgtk), Nothing, (Ptr{GObject},), win)
+fullscreen(win::GtkWindow) = (handle_auto_idle(win); ccall((:gtk_window_fullscreen, libgtk), Nothing, (Ptr{GObject},), win))
 unfullscreen(win::GtkWindow) = ccall((:gtk_window_unfullscreen, libgtk), Nothing, (Ptr{GObject},), win)
 
 maximize(win::GtkWindow) = ccall((:gtk_window_maximize, libgtk), Nothing, (Ptr{GObject},), win)


### PR DESCRIPTION
As reported in https://github.com/JuliaGraphics/Gtk.jl/issues/503 & https://github.com/JuliaLang/julia/issues/35552 loading Gtk in a julia session basically ruins the performance of the session from there-on out, especially threading.

Fixing the core issue appears to be intrinsic to how julia runs threads, and might take a while to fix(?)

So... this PR:

- Introduces `Gtk.enable_eventloop(b::Bool)` for start/stopping the GLib event loop, which prevents blocking other julia tasks/threads
- By default starts Gtk in idle state with no event loop
- The event loop is then started with any call to `show` or `showall` so that rendering always starts when something is shown
- Then stops the eventloop when all `show`-ed widgets have been destroyed
- Previous behavior can be regained via setting env var "GTK_AUTO_IDLE" to "false", or `Gtk.AUTO_IDLE[] = false`

~~Big caveat:~~
~~I followed [this](https://www.manpagez.com/html/glib/glib-2.56.0/glib-The-Main-Event-Loop.php#GSource) for guidance on what `uv_prepare` and `uv_check` should return to set idle state, but it's all effectively just setting the timeout to 0, resulting in a cpu thread at 100%. It would clearly be better to start/stop the main thread, so it would be good to implement what @StefanMathis demoed here https://github.com/JuliaGraphics/Gtk.jl/issues/503#issuecomment-980631162~~
Update: This now fully starts/stops the eventloop, so no cpu penalty.

## Example

#### Currently execution is slowed from the moment Gtk is launched
```julia
julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  0.124272 seconds (43.64 k allocations: 2.401 MiB, 19.35% compilation time)

julia> @time using ProfileView
Gtk-Message: 00:04:43.548: Failed to load module "canberra-gtk-module"
Gtk-Message: 00:04:43.549: Failed to load module "canberra-gtk-module"
  2.335983 seconds (6.44 M allocations: 363.227 MiB, 4.19% gc time, 54.24% compilation time)

julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  5.116726 seconds (15.36 k allocations: 839.915 KiB, 0.20% compilation time)

julia> @time @profview sleep(1);
  2.141247 seconds (3.60 M allocations: 195.752 MiB, 2.05% gc time, 51.75% compilation time)

julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  5.115667 seconds (15.36 k allocations: 839.884 KiB, 0.18% compilation time)

## Gtk window closed here ##

julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  5.114526 seconds (15.36 k allocations: 839.931 KiB, 0.15% compilation time)
```

#### With this PR, execution is only slowed when the Gtk window is open and static
```julia
julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  0.123857 seconds (43.64 k allocations: 2.401 MiB, 18.54% compilation time)

julia> @time using ProfileView
Gtk-Message: 00:01:48.147: Failed to load module "canberra-gtk-module"
Gtk-Message: 00:01:48.147: Failed to load module "canberra-gtk-module"
  2.347176 seconds (6.44 M allocations: 362.962 MiB, 6.95% gc time, 52.47% compilation time)

julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  0.113058 seconds (15.35 k allocations: 839.790 KiB, 10.38% compilation time)

julia> @time @profview sleep(1);
  2.278810 seconds (3.60 M allocations: 196.749 MiB, 1.81% gc time, 49.04% compilation time)

julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  5.116526 seconds (15.36 k allocations: 839.884 KiB, 0.18% compilation time)

## Gtk window closed here. ##

julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  0.110775 seconds (15.35 k allocations: 839.228 KiB, 8.27% compilation time)

julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  0.110090 seconds (15.35 k allocations: 839.790 KiB, 8.71% compilation time)

julia> @time Threads.@threads for _ in 1:Threads.nthreads()
       sleep(0.1)
       end
  0.109473 seconds (15.35 k allocations: 839.790 KiB, 8.32% compilation time)
```

## Notes

1) Note that the blocking still happens while windows are open and static, so this is just a bandaid.