### PR TITLE
Add a yield for windows (fix #610). Fix window not finishing close on MacOS

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -145,26 +145,30 @@ end
 
 const auto_idle = Ref{Bool}(true) # control default via ENV["GTK_AUTO_IDLE"]
 const gtk_main_running = Ref{Bool}(false)
-
+const quit_task = Ref{Task}()
+const enable_eventloop_lock = Base.ReentrantLock()
 """
     Gtk.enable_eventloop(b::Bool = true)
 
 Set whether Gtk's event loop is running.
 """
 function enable_eventloop(b::Bool = true)
-    if b
-        if !is_eventloop_running()
-            global gtk_main_task = schedule(Task(gtk_main))
-            gtk_main_running[] = true
-        end
-    else
-        if is_eventloop_running()
-            # @async and short sleep is needer on MacOS at least, otherwise
-            # the window doesn't always finish closing before the eventloop stops.
-            @async begin
-                sleep(0.2)
-                gtk_quit()
-                gtk_main_running[] = false
+    lock(enable_eventloop_lock) do # handle widgets that are being shown/destroyed from different threads
+        isassigned(quit_task) && wait(quit_task[]) # prevents starting while the async is still stopping
+        if b
+            if !is_eventloop_running()
+                global gtk_main_task = schedule(Task(gtk_main))
+                gtk_main_running[] = true
+            end
+        else
+            if is_eventloop_running()
+                # @async and short sleep is needer on MacOS at least, otherwise
+                # the window doesn't always finish closing before the eventloop stops.
+                quit_task[] = @async begin
+                    sleep(0.2)
+                    gtk_quit()
+                    gtk_main_running[] = false
+                end
             end
         end
     end

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -159,8 +159,13 @@ function enable_eventloop(b::Bool = true)
         end
     else
         if is_eventloop_running()
-            gtk_quit()
-            gtk_main_running[] = false
+            # @async and short sleep is needer on MacOS at least, otherwise
+            # the window doesn't always finish closing before the eventloop stops.
+            @async begin
+                sleep(0.2)
+                gtk_quit()
+                gtk_main_running[] = false
+            end
         end
     end
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -39,6 +39,7 @@ function handle_auto_idle(w::GtkWidget)
                 isempty(shown_widgets) && enable_eventloop(false)
             end
         end
+        Sys.iswindows() && yield() # issue #610
     end
 end
 function show(w::GtkWidget)

--- a/src/base.jl
+++ b/src/base.jl
@@ -34,7 +34,7 @@ function handle_auto_idle(w::GtkWidget)
         signal_connect(w, :realize) do w
             enable_eventloop(true)
             shown_widgets[w] = nothing
-            signal_connect(w, :destroy) do w
+            signal_connect(w, :destroy, #= after =# true) do w
                 delete!(shown_widgets, w)
                 isempty(shown_widgets) && enable_eventloop(false)
             end

--- a/src/base.jl
+++ b/src/base.jl
@@ -39,7 +39,7 @@ function handle_auto_idle(w::GtkWidget)
                 isempty(shown_widgets) && enable_eventloop(false)
             end
         end
-        Sys.iswindows() && yield() # issue #610
+        @static Sys.iswindows() && yield() # issue #610
     end
 end
 function show(w::GtkWidget)


### PR DESCRIPTION
Fixes #610
The fix indicated to work for @Vexatos https://github.com/JuliaGraphics/Gtk.jl/issues/610#issuecomment-1013760658
I'm not aware of this needing to be done outside of Windows, so decided to be conservative.

Also fixes an issue on MacOS where the window doesn't always close and freezes. 
It seems like there's a sequencing bug on MacOS, as it's pretty normal to call `quit_main` on `:destroy`
The async wait just gives some time for the window to finish closing.
