### PR TITLE
Add pause_eventloop for do-block syntax

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -38,4 +38,30 @@ destroy(win)
 
 @test isa(Gtk.GdkEventKey(), Gtk.GdkEventKey)
 
+@testset "Eventloop control" begin
+    before = Gtk.auto_idle[]
+
+    Gtk.enable_eventloop(true)
+    @test Gtk.is_eventloop_running()
+
+    Gtk.auto_idle[] = true
+    Gtk.pause_eventloop() do
+        @test !Gtk.is_eventloop_running()
+    end
+    @test Gtk.is_eventloop_running()
+
+    Gtk.auto_idle[] = false
+    Gtk.pause_eventloop() do
+        @test Gtk.is_eventloop_running()
+    end
+    @test Gtk.is_eventloop_running()
+
+    Gtk.pause_eventloop(force = true) do
+        @test !Gtk.is_eventloop_running()
+    end
+    @test Gtk.is_eventloop_running()
+
+    Gtk.auto_idle[] = before
+end
+
 end


### PR DESCRIPTION
A do-block syntax like this is helpful for running functions where you explicitly don't want the eventloop running.
```
pause_eventloop() do
    foo()
end
```
