### PR TITLE
Support `deleteat!` for all `GtkContainer`s

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -6,6 +6,19 @@ function delete!(w::GtkContainer, child::GtkWidget)
     ccall((:gtk_container_remove, libgtk), Nothing, (Ptr{GObject}, Ptr{GObject},), w, child)
     w
 end
+
+function Base.deleteat!(w::GtkContainer, i::Integer)
+    i isa Bool && depwarn("passing Bool as an index is deprecated", :deleteat!)
+    delete!(w, w[i])
+    w
+end
+function Base.deleteat!(w::GtkContainer, iterator)
+    for child in [w[i] for i in iterator]
+        delete!(w, child)
+    end
+    w
+end
+
 function empty!(w::GtkContainer)
     for child in w
         delete!(w, child)

--- a/src/container.jl
+++ b/src/container.jl
@@ -8,7 +8,7 @@ function delete!(w::GtkContainer, child::GtkWidget)
 end
 
 function Base.deleteat!(w::GtkContainer, i::Integer)
-    i isa Bool && depwarn("passing Bool as an index is deprecated", :deleteat!)
+    i isa Bool && Base.depwarn("passing Bool as an index is deprecated", :deleteat!)
     delete!(w, w[i])
     w
 end
@@ -18,7 +18,8 @@ function Base.deleteat!(w::GtkContainer, iterator)
     end
     w
 end
-
+Base.firstindex(w::GtkContainer) = 1
+Base.lastindex(w::GtkContainer) = length(w)
 function empty!(w::GtkContainer)
     for child in w
         delete!(w, child)


### PR DESCRIPTION
Found `GtkButton`s were not supported to `deleteat!` before.
Now add it.