### PR TITLE
add option for "simple" main loop iteration

### DIFF
--- a/src/GLib/signals.jl
+++ b/src/GLib/signals.jl
@@ -404,7 +404,7 @@ const simple_loop = Ref{Bool}(false)
 
 const exiting = Ref(false)
 function __init__()
-    simple_loop[] = get(ENV, "GTK_SIMPLE_LOOP", "false") == "true"
+    simple_loop[] = get(ENV, "GTK_SIMPLE_LOOP", "true") == "true"
     if isdefined(GLib, :__init__bindeps__)
         GLib.__init__bindeps__()
     end

--- a/src/GLib/signals.jl
+++ b/src/GLib/signals.jl
@@ -400,8 +400,11 @@ macro idle_add(ex)
     end
 end
 
+const simple_loop = Ref{Bool}(false)
+
 const exiting = Ref(false)
 function __init__()
+    simple_loop[] = get(ENV, "GTK_SIMPLE_LOOP", "false") == "true"
     if isdefined(GLib, :__init__bindeps__)
         GLib.__init__bindeps__()
     end
@@ -410,6 +413,8 @@ function __init__()
     exiting[] = false
     atexit(() -> (exiting[] = true))
     __init__gtype__()
-    __init__gmainloop__()
+    if !simple_loop[]
+        __init__gmainloop__()
+    end
     nothing
 end

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -178,9 +178,7 @@ iteration(may_block::Bool) = ccall((:g_main_context_iteration, libglib), Cint, (
 
 const pause_loop = Ref{Bool}(false)
 
-function iterate(timer)
-    pause_loop[] || iteration(false)
-end
+iterate(timer) = pause_loop[] || iteration(false)
 
 events_pending() = ccall((:gtk_events_pending, libgtk), Cint, ()) != 0
 
@@ -264,13 +262,7 @@ end
 
 Check whether Gtk's event loop is running.
 """
-function is_eventloop_running()
-    if GLib.simple_loop[]
-        return !pause_loop[]
-    else
-        return gtk_main_running[]
-    end
-end
+is_eventloop_running() = GLib.simple_loop[] ? !pause_loop[] : gtk_main_running[]
 
 const ser_version = Serialization.ser_version
 let cachedir = joinpath(splitdir(@__FILE__)[1], "..", "gen")

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -168,7 +168,7 @@ function __init__()
     # that call to also start the eventloop
     GLib.gtk_eventloop_f[] = enable_eventloop
 
-    auto_idle[] = get(ENV, "GTK_AUTO_IDLE", "true") == "true"
+    auto_idle[] = get(ENV, "GTK_AUTO_IDLE", "false") == "true"
 
     # by default, defer starting the event loop until either `show`, `showall`, or `g_idle_add` is called
     enable_eventloop(!auto_idle[])

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -177,6 +177,7 @@ end
 iteration(may_block::Bool) = ccall((:g_main_context_iteration, libglib), Cint, (Ptr{Cvoid}, Cint), C_NULL, may_block)
 
 iterate(timer) = iteration(false)
+events_pending() = ccall((:gtk_events_pending, libgtk), Cint, ()) != 0
 
 function glib_main_simple()
     t=Timer(iterate,0.01;interval=0.005)

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -77,6 +77,7 @@ include("gio.jl")
 include("application.jl")
 
 function __init__()
+    Sys.iswindows() && (ENV["GTK_CSD"] = 0)
     # Set XDG_DATA_DIRS so that Gtk can find its icons and schemas
     ENV["XDG_DATA_DIRS"] = join(filter(x -> x !== nothing, [
         dirname(adwaita_icons_dir),

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -248,14 +248,14 @@ function pause_eventloop(f; force = false)
         finally
             pause_loop[] = false
         end
-        return
-    end
-    was_running = is_eventloop_running()
-    (force || auto_idle[]) && enable_eventloop(false, wait_stopped = true)
-    try
-        f()
-    finally
-        (force || auto_idle[]) && enable_eventloop(was_running)
+    else
+        was_running = is_eventloop_running()
+        (force || auto_idle[]) && enable_eventloop(false, wait_stopped = true)
+        try
+            f()
+        finally
+            (force || auto_idle[]) && enable_eventloop(was_running)
+        end
     end
 end
 

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -183,7 +183,11 @@ function will wait until events are ready to be processed. Otherwise, it will
 return immediately if no events need to be processed. Returns `true` if events
 were processed.
 """
-iteration(may_block::Bool) = ccall((:g_main_context_iteration, libglib), Cint, (Ptr{Cvoid}, Cint), C_NULL, may_block) != 0
+function iteration(may_block::Bool)
+    while events_pending()
+        ccall((:g_main_context_iteration, libglib), Cint, (Ptr{Cvoid}, Cint), C_NULL, may_block)
+    end
+end
 
 const pause_loop = Ref{Bool}(false)
 

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -174,12 +174,12 @@ function __init__()
     enable_eventloop(!auto_idle[])
 end
 
-function iteration(timer)
-    ccall((:g_main_context_iteration, libglib), Cint, (Ptr{Cvoid}, Cint), C_NULL, false)
-end
+iteration(may_block::Bool) = ccall((:g_main_context_iteration, libglib), Cint, (Ptr{Cvoid}, Cint), C_NULL, may_block)
+
+iterate(timer) = iteration(false)
 
 function glib_main_simple()
-    t=Timer(iteration,0.01;interval=0.005)
+    t=Timer(iterate,0.01;interval=0.005)
     wait(t)
 end
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -22,7 +22,7 @@ visible(w::GtkWidget, state::Bool) = @sigatom ccall((:gtk_widget_set_visible, li
 
 const shown_widgets = WeakKeyDict()
 function handle_auto_idle(w::GtkWidget)
-    if auto_idle[]
+    if auto_idle[] && !GLib.simple_loop[]
         signal_connect(w, :realize) do w
             enable_eventloop(true)
             shown_widgets[w] = nothing

--- a/src/cairo.jl
+++ b/src/cairo.jl
@@ -115,6 +115,9 @@ function canvas_on_expose_event(::Ptr{GObject}, e::Ptr{Nothing}, widget::GtkCanv
 end
 
 function getgc(c::GtkCanvas)
+    while events_pending()  # next step requires a realized canvas
+        iteration(true)
+    end
     if !isdefined(c,:backcc)
       error("GtkCanvas not yet initialized.")
     end

--- a/src/cairo.jl
+++ b/src/cairo.jl
@@ -115,7 +115,7 @@ function canvas_on_expose_event(::Ptr{GObject}, e::Ptr{Nothing}, widget::GtkCanv
 end
 
 function getgc(c::GtkCanvas)
-    while events_pending()  # next step requires a realized canvas
+    while GLib.simple_loop[] && events_pending()  # next step requires a realized canvas
         iteration(true)
     end
     if !isdefined(c,:backcc)

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -612,6 +612,9 @@ end
         set_coordinates(getgc(c), BoundingBox(0, 1, 0, 1))
     end
     Gtk.showall(win)
+    while ccall((:gtk_events_pending, Gtk.libgtk), Cint, ()) != 0  # next step requires a realized canvas
+        Gtk.iteration(true)
+    end
     sleep(0.5)
     mtrx = Gtk.Cairo.get_matrix(getgc(cnvs))
     @test mtrx.xx == 300

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -612,9 +612,6 @@ end
         set_coordinates(getgc(c), BoundingBox(0, 1, 0, 1))
     end
     Gtk.showall(win)
-    while ccall((:gtk_events_pending, Gtk.libgtk), Cint, ()) != 0  # next step requires a realized canvas
-        Gtk.iteration(true)
-    end
     sleep(0.5)
     mtrx = Gtk.Cairo.get_matrix(getgc(cnvs))
     @test mtrx.xx == 300

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -38,6 +38,8 @@ destroy(win)
 
 @test isa(Gtk.GdkEventKey(), Gtk.GdkEventKey)
 
+if !Gtk.GLib.simple_loop[]
+
 @testset "Eventloop control" begin
     before = Gtk.auto_idle[]
 
@@ -62,6 +64,8 @@ destroy(win)
     @test Gtk.is_eventloop_running()
 
     Gtk.auto_idle[] = before
+end
+
 end
 
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -66,6 +66,18 @@ if !Gtk.GLib.simple_loop[]
     Gtk.auto_idle[] = before
 end
 
+else
+
+@testset "Eventloop control" begin
+    Gtk.enable_eventloop(true)
+    @test Gtk.is_eventloop_running()
+
+    Gtk.pause_eventloop() do
+        @test !Gtk.is_eventloop_running()
+    end
+    @test Gtk.is_eventloop_running()
+end
+
 end
 
 end


### PR DESCRIPTION
I hesitated to post this because it seems too good to be true. This PR creates a "simple" main loop option (disabled by default) that replaces the call to `gtk_main()` with a Timer that iterates the GLib main loop every 5 ms in a non-blocking way. It also skips the call to `__init__gmainloop__()`, completely omitting the creation of a GSource for libuv. This is enabled using GTK_SIMPLE_LOOP = true.

When I run Julia 1.7 with `GTK_SIMPLE_LOOP=true GTK_AUTO_IDLE=false JULIA_NUM_THREADS=4`, I don't see a slowdown in the multithread tests posted at the beginning of #503. All Gtk.jl tests pass for me locally on Linux and Windows. ProfileView, ImageView and Winston seem to work just fine.

Am I missing something? It's very possible I just haven't managed to create the situations that led to the tight integration of the libuv loop with the GLib loop. On the other hand, that code is ~8 years old and maybe isn't needed in recent versions of Julia?