### PR TITLE
Fix async UI example

### DIFF
--- a/docs/src/manual/async.md
+++ b/docs/src/manual/async.md
@@ -1,11 +1,14 @@
 # Asynchronous UI
 
-Here is an example of an asynchronous update of the user interface. Since
-Julia has currently no possibility of multithreading we use a second process
-to offload the work. The example is just a proof of principle.
+Here is an example of an asynchronous update of the user interface.
+Since Julia has currently no possibility of multithreading
+we use a second process to offload the work.
+The example is just a proof of principle.
 
 ```julia
-using Gtk
+using Gtk: GtkButton, GtkSpinner, GtkEntry, GtkGrid, GtkWindow
+using Gtk: start, stop, signal_connect, set_gtk_property!, showall, @sigatom
+using Distributed: addprocs, @fetchfrom
 
 btn = GtkButton("Start")
 sp = GtkSpinner()
@@ -20,13 +23,13 @@ id = addprocs(1)[1]
 
 signal_connect(btn, "clicked") do widget
  start(sp)
- @Gtk.sigatom begin
+ @sigatom begin
    @async begin
     s = @fetchfrom id begin
       sleep(4)
       return "I am back"
     end
-    @Gtk.sigatom begin
+    @sigatom begin
       stop(sp)
       set_gtk_property!(ent,:text,s)
     end
@@ -37,5 +40,3 @@ end
 win = GtkWindow(grid, "Progress Bar", 200, 200)
 showall(win)
 ```
-
-


### PR DESCRIPTION
The Asynchronous UI example does not run as presented in the docs
because `addprocs` and `@fetchfrom` are now in `Distributed`,
so this PR addresses that issue.

Along the way, this PR also fully qualifies all the methods that are used from `Gtk`
so that is clear to new users (and old users like myself with limited memory)
where functions originate, especially useful for those with general names like `start` and `showall`.

The text at the top of these docs says that "Julia has currently no possibility of multithreading"
which seems likely to be an outdated claim, in light of `Threads.@threads` etc.
Before merging this PR, please reword those lines (maintainers can edit) or offer advice on how to reword.  I wasn't quite sure how to reword because I don't fully understand this example.