### PR TITLE
add coveralls flag-name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.julia-arch }}
+    name: Julia ${{ join(matrix.*, ' - ') }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -55,10 +55,27 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           prefix: ${{ matrix.prefix }}
-      - uses: julia-actions/julia-uploadcodecov@v0.1
-        continue-on-error: true
-      - uses: julia-actions/julia-uploadcoveralls@v0.1
-        continue-on-error: true
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: lcov.info
+          flag-name: Julia ${{ join(matrix.*, ' - ') }}
+          parallel: true
+
+  finish:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true
 
   Documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds `parallel: true`, which is mandatory if you are using a build matrix. (This was also supported with the old uploader via environment variables, but this also switches to the official uploader).

n.b. this previously has always failed with 'ERROR: Coveralls submission requires a COVERALLS_TOKEN environment variable'