### PR TITLE
Tiny fix in documentation code snippet about GtkTreeModelFilter

### DIFF
--- a/docs/src/manual/listtreeview.md
+++ b/docs/src/manual/listtreeview.md
@@ -187,7 +187,7 @@ signal_connect(selection, "changed") do widget
     currentIt = selected(selection)
 
     println("Name: ", GtkTreeModel(tmFiltered)[currentIt,1],
-            " Age: ", GtkTreeModel(tmFiltered)[currentIt,1])
+            " Age: ", GtkTreeModel(tmFiltered)[currentIt,2])
   end
 end
 


### PR DESCRIPTION
Age is in 2nd column instead of 1st.

Console output when selecting a row, before fix:
`Name: Peter Age: Peter`

After this fix:
`Name: Peter Age: 20`