### PR TITLE
fail in __init__() with error if Gtk4 was previously imported

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -77,6 +77,8 @@ include("gio.jl")
 include("application.jl")
 
 function __init__()
+    in(:Gtk4, names(Main, imported=true)) && error("Gtk is incompatible with Gtk4.")
+
     # Set XDG_DATA_DIRS so that Gtk can find its icons and schemas
     ENV["XDG_DATA_DIRS"] = join(filter(x -> x !== nothing, [
         dirname(adwaita_icons_dir),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,5 +7,4 @@ include("gui.jl")
 include("list.jl")
 include("misc.jl")
 include("text.jl")
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,5 @@ include("gui.jl")
 include("list.jl")
 include("misc.jl")
 include("text.jl")
-include("tree.jl")
 
 end


### PR DESCRIPTION
This prevents Julia from crashing.

Also remove redundant tests that I introduced.