### PR TITLE
Remove outdated warning in docs

### DIFF
--- a/docs/src/manual/signals.md
+++ b/docs/src/manual/signals.md
@@ -83,9 +83,3 @@ id = signal_connect((widget, event) -> cb_buttonpressed(widget, event, guistate,
 ```
 
 In some situations you may want or need to use an [approach that is more analogous to julia's `@cfunction` callback syntax](../doc/more_signals.md). One advantage of this alternative approach is that, in cases of error, the backtraces are much more informative.
-
-Warning: it is essential to avoid task switching inside Gtk callbacks,
-as this corrupts the Gtk C-stack. For example, use `@async print` or queue a message for yourself.
-You can also call `GLib.g_yield()` if you need to block. However, if you are still seeing segfaults in some random method due to there existing a callback that recursively calls the glib main loop (such as making a dialog box) or otherwise causes `g_yield` to be called, wrap the faulting code in `GLib.@sigatom`. This will postpone execution of that code block until it can be run on the proper stack (but will otherwise acts like normal control flow).
-
-These restrictions should be fixed once https://github.com/JuliaLang/julia/pull/13099 is merged.


### PR DESCRIPTION
I'm assuming that these restrictions are fixed now that the PR has merged, but I don't know for sure.
Closes #637 