### PR TITLE
Handle multiple keypresses in example

### DIFF
--- a/docs/src/manual/keyevents.md
+++ b/docs/src/manual/keyevents.md
@@ -29,22 +29,22 @@ and reports the time duration between the two.
 There some state handling here
 because of the likely event
 that your keyboard is set to "repeat" a pressed key
-after some initial delay.
+after some initial delay and because it is possilbe to 
+press multiple keys at once.
 This version reports the time elapsed
 between the _initial_ key press and the key release.
 
 ```julia
 using Gtk
 
-time0 = nothing
+const start_times = Dict{UInt32, UInt32}()
 
 w = GtkWindow("Key Press/Release Example")
 
 id1 = signal_connect(w, "key-press-event") do widget, event
     k = event.keyval
-    global time0
-    if isnothing(time0)
-        time0 = event.time # archive the initial key press time
+    if k ∉ keys(start_times)
+        start_times[k] = event.time # save the initial key press time
         println("You pressed key ", k, " which is '", Char(k), "'.")
     else
         println("repeating key ", k)
@@ -53,8 +53,8 @@ end
 
 id2 = signal_connect(w, "key-release-event") do widget, event
     k = event.keyval
-    duration = event.time - time0 # key press duration in msec
+    start_time = pop!(start_times, k) # remove the key from the dictionary
+    duration = event.time - start_time # key press duration in milliseconds
     println("You released key ", k, " after time ", duration, " msec.")
-    global time0 = nothing # revert to original state for next press
 end
 ```


### PR DESCRIPTION
Two sequential releases resulted in an error because the first set `time0` to `notihing` and the second tried to use `time0`.

Before:
```
julia> You pressed key 97 which is 'a'.
repeating key 115
repeating key 100
You released key 97 after time 121 msec.
┌ Warning: Executing #51:
└ @ Gtk.GLib ~/.julia/packages/Gtk/OyCvN/src/GLib/signals.jl:106
ERROR: MethodError: no method matching -(┌ Warning: Executing #51:
└ @ Gtk.GLib ~/.julia/packages/Gtk/OyCvN/src/GLib/signals.jl:106
::ERROR: UInt32MethodError: , no method matching ::-Nothing()::
Closest candidates are:
  -(::Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}) at int.jl:85
  -(::T, ::T) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8} at int.jl:86
  -(::Union{UInt16, UInt32, UInt64, UInt8}, ::BigInt) at gmp.jl:534
  ...UInt32, 
Stacktrace:
 [1] ::(::var"#51#52")Nothing()widget
Closest candidates are:
  -(::Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}) at int.jl:85
  -(::T, ::T) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8} at int.jl:86
  -(::Union{UInt16, UInt32, UInt64, UInt8}, ::BigInt) at gmp.jl:534
  ...::
Stacktrace:GtkWindowLeaf
,  event[1]:: Gtk.GdkEventKey(::var"#51#52"))(
widget   @ ::MainGtkWindowLeaf , ./eventREPL[346]:3::Gtk.GdkEventKey
) 
[2]   @  Main(::Gtk.GLib.var"#90#92"{Ptr{Gtk.GLib.GValue}, UInt32, Ptr{Gtk.GLib.GValue}, Vector{Any}, Bool, var"#51#52", Ptr{Any}}) (./)REPL[346]:3
   @ 
Gtk.GLib  [2]~/.julia/packages/Gtk/OyCvN/src/GLib/ signals.jl:87(::Gtk.GLib.var"#90#92"{Ptr{Gtk.GLib.GValue}, UInt32, Ptr{Gtk.GLib.GValue}, Vector{Any}, Bool, var"#51#52", Ptr{Any}})(
) 
[3]   @  Gtk.GLibg_siginterruptible (~/.julia/packages/Gtk/OyCvN/src/GLib/fsignals.jl:87::Gtk.GLib.var"#90#92"
{Ptr{Gtk.GLib.GValue}, UInt32, Ptr{Gtk.GLib.GValue}, Vector{Any}, Bool, var"#51#52", Ptr{Any}} , [3]cb ::g_siginterruptibleAny()f
::   @ Gtk.GLib.var"#90#92"Gtk.GLib{Ptr{Gtk.GLib.GValue}, UInt32, Ptr{Gtk.GLib.GValue}, Vector{Any}, Bool, var"#51#52", Ptr{Any}} , ~/.julia/packages/Gtk/OyCvN/src/GLib/cbsignals.jl:216::Any
) 
[4]   @  Gtk.GLibGClosureMarshal (~/.julia/packages/Gtk/OyCvN/src/GLib/closurefsignals.jl:216::Ptr
{Nothing} , [4]return_value ::GClosureMarshalPtr({Gtk.GLib.GValue}closuref, ::n_param_valuesPtr::{Nothing}UInt32, , return_valueparam_values::::PtrPtr{Gtk.GLib.GValue}{Gtk.GLib.GValue}, , n_param_valuesinvocation_hint::::UInt32Ptr, {Nothing}param_values, ::marshal_dataPtr::{Gtk.GLib.GValue}Ptr, {Nothing}invocation_hint)::
Ptr   @ {Nothing}Gtk.GLib,  marshal_data~/.julia/packages/Gtk/OyCvN/src/GLib/::signals.jl:58Ptr{Nothing}
) 
[5]   @  Gtk.GLib(::Gtk.var"#253#254") (~/.julia/packages/Gtk/OyCvN/src/GLib/)signals.jl:58
   @ 
Gtk  [5]~/.julia/packages/Gtk/OyCvN/src/ events.jl:2(::Gtk.var"#253#254")(
) 
[6]   @  Gtkg_sigatom (~/.julia/packages/Gtk/OyCvN/src/fevents.jl:2::Any
) 
[6]   @  Gtk.GLibg_sigatom (~/.julia/packages/Gtk/OyCvN/src/GLib/fsignals.jl:176::Any
) 
[7]   @  Gtk.GLibgtk_main (~/.julia/packages/Gtk/OyCvN/src/GLib/)signals.jl:176
   @ 
Gtk  [7]~/.julia/packages/Gtk/OyCvN/src/ events.jl:1gtk_main(
)

   @ Gtk ~/.julia/packages/Gtk/OyCvN/src/events.jl:1
```
After:
```
You pressed key 97 which is 'a'.
You pressed key 115 which is 's'.
You pressed key 100 which is 'd'.
You released key 97 after time 109 msec.
You released key 115 after time 89 msec.
You released key 100 after time 89 msec.
```