### PR TITLE
avoid GList in empty!(c::GtkContainer)

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -28,6 +28,7 @@ function empty!(c::GtkContainer)
     remove_widget_c = @cfunction(_remove_widget, Nothing, (Ptr{GtkWidget}, Ptr{GObject}))
 
     ccall((:gtk_container_foreach, Gtk.libgtk), Nothing, (Ptr{GObject}, Ptr{Cvoid}, Ptr{GObject}), c, remove_widget_c, c)
+    c
 end
 function append!(w::GtkContainer, children)
     for child in children

--- a/src/container.jl
+++ b/src/container.jl
@@ -20,11 +20,14 @@ function Base.deleteat!(w::GtkContainer, iterator)
 end
 Base.firstindex(w::GtkContainer) = 1
 Base.lastindex(w::GtkContainer) = length(w)
-function empty!(w::GtkContainer)
-    for child in w
-        delete!(w, child)
-    end
-    w
+function _remove_widget(w, con)
+    ccall((:gtk_container_remove, Gtk.libgtk), Nothing, (Ref{GObject}, Ref{GtkWidget}), con, w)
+end
+
+function empty!(c::GtkContainer)
+    remove_widget_c = @cfunction(_remove_widget, Nothing, (Ptr{GtkWidget}, Ptr{GObject}))
+
+    ccall((:gtk_container_foreach, Gtk.libgtk), Nothing, (Ptr{GObject}, Ptr{Cvoid}, Ptr{GObject}), c, remove_widget_c, c)
 end
 function append!(w::GtkContainer, children)
     for child in children

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -53,17 +53,17 @@ function insert!(grid::GtkGrid, i::Integer, side::Symbol)
     elseif side == :bottom
         ccall((:gtk_grid_insert_row, libgtk), Nothing, (Ptr{GObject}, Cint), grid, i)
     else
-        error(string("invalid GtkPositionType ", s))
+        error(string("Unknown side parameter $side: must be left, right, top or bottom "))
     end
 end
 
-function deleteat!(grid::GtkGrid, i::Integer, side::Symbol)
-    if side == :row
-        ccall((:gtk_grid_remove_row, libgtk), Nothing, (Ptr{GObject}, Cint), grid, i)
-    elseif side == :col
-        ccall((:gtk_grid_remove_column, libgtk), Nothing, (Ptr{GObject}, Cint), grid, i)
+function deleteat!(grid::GtkGrid, i::Integer, rowcol::Symbol)
+    if rowcol == :row
+        ccall((:gtk_grid_remove_row, libgtk), Nothing, (Ptr{GObject}, Cint), grid, i-1)
+    elseif rowcol == :col
+        ccall((:gtk_grid_remove_column, libgtk), Nothing, (Ptr{GObject}, Cint), grid, i-1)
     else
-        error(string("invalid GtkPositionType ", s))
+        error(string("rowcol must be row or col, got ", rowcol))
     end
 end
 

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -131,11 +131,14 @@ end
 end
 
 @testset "Frame" begin
+fr=Frame()
 w = Window(
-    Frame(),
+    fr,
     "Frame", 400, 400)
 widgets=[f for f in w] # test iteration over GtkBin
 @test length(widgets)==1
+e=[c for c in fr] # test iteration over an empty GtkBin
+@test length(e)==0
 showall(w)
 destroy(w)
 end
@@ -179,6 +182,8 @@ showall(w)
 set_gtk_property!(nb,:page,2)
 @test get_gtk_property(nb,:page,Int) == 2
 showall(w)
+empty!(nb)
+@test length(nb) == 0
 destroy(w)
 end
 
@@ -242,6 +247,10 @@ set_gtk_property!(g2,:pack_type,b21,1) #GTK_PACK_END
 set_gtk_property!(g2,:pack_type,b22,1) #GTK_PACK_END
 @test get_gtk_property(g1,:pack_type, b11, Int) == 0
 
+@test length(g1)==2
+deleteat!(g1,1)
+@test length(g1)==1
+
 ## Now shrink window
 showall(w)
 destroy(w)
@@ -275,9 +284,12 @@ end
     insert!(grid,1,:top)
     insert!(grid,3,:bottom)
     insert!(grid,grid[1,2],:right)
+    @test_throws ErrorException insert!(grid,6,:above)
+    @test_throws ErrorException deleteat!(grid,6,:below)
     libgtk_version >= v"3.10.0" && deleteat!(grid,1,:row)
     showall(w)
     empty!(grid)
+    @test length(grid)==0
     destroy(w)
 end
 


### PR DESCRIPTION
Also provide useful errors in a couple of GtkGrid methods.

Fixes #669 