### PR TITLE
new configure! methods for GtkAdjustment and GtkSpinButton

### DIFF
--- a/src/input.jl
+++ b/src/input.jl
@@ -39,9 +39,60 @@ GtkAdjustmentLeaf(value, lower, upper, step_increment, page_increment, page_size
 GtkAdjustmentLeaf(scale::GtkScale) = convert(GtkAdjustmentLeaf,
     ccall((:gtk_range_get_adjustment, libgtk), Ptr{GObject}, (Ptr{GObject},), scale))
 
+"""
+    configure!(adj::GtkAdjustment; value = nothing, lower = nothing, upper = nothing, step_increment = nothing, page_increment = nothing, page_size = nothing)
+
+Sets all properties of an adjustment, while only resulting in one emission of
+the `changed` signal. If an argument is `nothing`, it is not changed.
+"""
+function configure!(adj::GtkAdjustment; value = nothing, lower = nothing, upper = nothing, step_increment = nothing, page_increment = nothing, page_size = nothing)
+    if value === nothing
+        value = G_.value(adj)
+    end
+    if lower === nothing
+        lower = G_.lower(adj)
+    end
+    if upper === nothing
+        upper = G_.upper(adj)
+    end
+    if step_increment === nothing
+        step_increment = G_.step_increment(adj)
+    end
+    if page_increment === nothing
+        page_increment = G_.page_increment(adj)
+    end
+    if page_size === nothing
+        page_size = G_.page_size(adj)
+    end
+    ccall((:gtk_adjustment_configure, libgtk), Nothing,
+                      (Ptr{GObject}, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble),
+                      adj, value, lower, upper, step_increment, page_increment, page_size)
+end
+
 GtkSpinButtonLeaf(min, max, step) = GtkSpinButtonLeaf(
     ccall((:gtk_spin_button_new_with_range, libgtk), Ptr{GObject}, (Cdouble, Cdouble, Cdouble), min, max, step))
 GtkSpinButtonLeaf(scale::AbstractRange) = GtkSpinButtonLeaf(minimum(scale), maximum(scale), step(scale))
 
 GtkAdjustmentLeaf(spinButton::GtkSpinButton) = convert(GtkAdjustmentLeaf,
     ccall((:gtk_spin_button_get_adjustment, libgtk), Ptr{GObject}, (Ptr{GObject},), spinButton))
+
+"""
+    configure!(sb::GtkSpinButton; adj = nothing, climb_rate = nothing, digits = nothing)
+
+Sets the adjustment `adj`, the `climb_rate`, and the number of `digits` of
+a `GtkSpinButton` with only one emission of its `changed` signal. If an argument is
+`nothing`, it is not changed.
+"""
+function configure!(sb::GtkSpinButton; adj = nothing, climb_rate = nothing, digits = nothing)
+    if adj === nothing
+        adj = C_NULL
+    end
+    if climb_rate === nothing
+        climb_rate = get_gtk_property(sb, :climb_rate, Float64)
+    end
+    if digits === nothing
+        digits = G_.digits(sb)
+    end
+    ccall((:gtk_spin_button_configure, libgtk), Nothing,
+                (Ptr{GObject}, Ptr{GObject}, Cdouble, Cuint), sb, adj, climb_rate, digits)
+end

--- a/src/input.jl
+++ b/src/input.jl
@@ -80,8 +80,7 @@ GtkAdjustmentLeaf(spinButton::GtkSpinButton) = convert(GtkAdjustmentLeaf,
     configure!(sb::GtkSpinButton; adj = nothing, climb_rate = nothing, digits = nothing)
 
 Sets the adjustment `adj`, the `climb_rate`, and the number of `digits` of
-a `GtkSpinButton` with only one emission of its `changed` signal. If an argument is
-`nothing`, it is not changed.
+a `GtkSpinButton`. If an argument is `nothing`, it is not changed.
 """
 function configure!(sb::GtkSpinButton; adj = nothing, climb_rate = nothing, digits = nothing)
     if adj === nothing

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -528,6 +528,16 @@ G_.value(sl, 3)
 adj = Adjustment(sl)
 @test get_gtk_property(adj,:value,Float64) == 3
 set_gtk_property!(adj,:upper,11)
+
+Gtk.configure!(adj) # nothing should change
+@test G_.value(sl) == 3
+@test get_gtk_property(adj, :upper, Float64) == 11
+
+Gtk.configure!(adj; value = 13, lower = 3, upper = 13)
+@test get_gtk_property(adj, :value, Float64) == 13
+@test get_gtk_property(adj, :lower, Float64) == 3
+@test get_gtk_property(adj, :upper, Float64) == 13
+
 destroy(w)
 end
 
@@ -536,6 +546,14 @@ sp = SpinButton(1:10)
 w = Window(sp, "SpinButton")|>showall
 G_.value(sp, 3)
 @test G_.value(sp) == 3
+digits = get_gtk_property(sp, :digits, Int64)
+
+Gtk.configure!(sp) # nothing should change
+@test get_gtk_property(sp, :digits, Int64) == digits
+
+Gtk.configure!(sp; digits = 2)
+@test get_gtk_property(sp, :digits, Int64) == 2
+
 destroy(w)
 end
 


### PR DESCRIPTION
Create wrappers for `gtk_adjustment_configure` and `gtk_spin_button_configure`, which let you alter multiple properties while emitting only one `changed` signal.