### PR TITLE
Make `Gtk` relocatable

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -10,9 +10,8 @@ using GTK3_jll, Glib_jll, Xorg_xkeyboard_config_jll, gdk_pixbuf_jll, adwaita_ico
 using Librsvg_jll
 using JLLWrappers
 using Pkg.Artifacts, Scratch
-const libgdk = libgdk3
-const libgtk = libgtk3
-const libgdk_pixbuf = libgdkpixbuf
+using GTK3_jll: libgdk3 as libgdk, libgtk3 as libgtk
+using gdk_pixbuf_jll: libgdkpixbuf as libgdk_pixbuf
 
 
 const suffix = :Leaf


### PR DESCRIPTION
Because `Gtk` copies some library names from the `GTK3_jll` module in a top-level directive, those values get baked in at precompile time.  This could be fixed by using `libgtk3` instead of `libgtk` everywhere, but we can also create a stateless binding by using the `using Foo: a as b` syntax, so this is the minimum change necessary.